### PR TITLE
Issue #55. The "'build.plugins.plugin.version' for org.apache.maven.p…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
                 <configuration>
                     <source>8</source>
                     <target>8</target>


### PR DESCRIPTION
…lugins:maven-compiler-plugin is missing" warning is fixed.