### PR TITLE
build(#506): replace removed javadocstyle check with summaryjavadoc

### DIFF
--- a/conf/checkstyle.xml
+++ b/conf/checkstyle.xml
@@ -93,7 +93,7 @@
             <property name="allowUnknownTags" value="true"/>
         </module>
         <module name="JavadocVariable"/>
-        <module name="JavadocStyle"/>
+        <module name="SummaryJavadoc"/>
         <module name="MissingJavadocMethod"/>
 
         <!-- Checks for Naming Conventions.                  -->


### PR DESCRIPTION
Checkstyle removed the `JavadocStyle` check in release 13.9.0
([checkstyle/checkstyle#20610](https://github.com/checkstyle/checkstyle/issues/20610)), so
`conf/checkstyle.xml` fails to initialise `TreeWalker` on any checkstyle version from 13.9.0
onwards — which is what breaks Dependabot's PR #503 (13.8.0 -> 14.0.0) and would break every
future checkstyle bump.

This replaces `<module name="JavadocStyle"/>` with `<module name="SummaryJavadoc"/>`, the
replacement named in the checkstyle release notes. Default properties are kept: they report
zero violations on the current sources, so no Javadoc needed fixing.

The pinned checkstyle version in `pom.xml` is deliberately left at 13.8.0 — `SummaryJavadoc`
exists there too, so this branch's build is unaffected, and #503 can rebase and go green on
its own.

Verified with the full build on JDK 21 with network access:

```
mvn clean install package javadoc:javadoc
```

`BUILD SUCCESS` — 0 checkstyle violations, 24/24 tests passing, PMD, duplicate-finder and
`jacoco:check` all clean. Also verified against the checkstyle 14.0.0 CLI directly: the
current config fails to initialise, and with this change it audits clean.

Closes #506