### PR TITLE
fix(#511): url-encode the search string and metadata path

### DIFF
--- a/src/main/java/com/github/aistomin/maven/browser/MavenCentral.java
+++ b/src/main/java/com/github/aistomin/maven/browser/MavenCentral.java
@@ -19,6 +19,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.module.ModuleDescriptor.Version;
 import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -103,7 +106,10 @@ public final class MavenCentral implements MvnRepo {
                 URI.create(
                     String.format(
                         "%s?q=%s&start=%d&rows=%d&wt=json",
-                        this.search, str, start, rows
+                        this.search,
+                        URLEncoder.encode(str, StandardCharsets.UTF_8),
+                        start,
+                        rows
                     )
                 ),
                 ENCODING
@@ -130,10 +136,18 @@ public final class MavenCentral implements MvnRepo {
     ) throws MvnException {
         try {
             final String url = String.format(
-                "%s/%s/%s/maven-metadata.xml",
+                "%s%s",
                 this.repo,
-                artifact.group().name().replace('.', '/'),
-                artifact.name()
+                new URI(
+                    null,
+                    null,
+                    String.format(
+                        "/%s/%s/maven-metadata.xml",
+                        artifact.group().name().replace('.', '/'),
+                        artifact.name()
+                    ),
+                    null
+                ).toASCIIString()
             );
             final List<String> allVersions = parseMetadataXml(
                 URI.create(url).toURL().openStream()
@@ -151,7 +165,7 @@ public final class MavenCentral implements MvnRepo {
                 )
                 .collect(Collectors.toList());
         } catch (final IOException | ParserConfigurationException
-            | SAXException exception) {
+            | SAXException | URISyntaxException exception) {
             throw new MvnException(exception);
         }
     }

--- a/src/main/java/com/github/aistomin/maven/browser/MvnRepo.java
+++ b/src/main/java/com/github/aistomin/maven/browser/MvnRepo.java
@@ -26,6 +26,8 @@ public interface MvnRepo {
 
     /**
      * Search for the artifacts. Returns first 20 found artifacts.
+     * The search string is URL-encoded before it is sent to the repository, so
+     * it may safely contain spaces and other special characters.
      *
      * @param str The search string. It may be a part of group or artifact name.
      * @return The list of the found artifacts.
@@ -35,6 +37,8 @@ public interface MvnRepo {
 
     /**
      * Search for the artifacts.
+     * The search string is URL-encoded before it is sent to the repository, so
+     * it may safely contain spaces and other special characters.
      *
      * @param str The search string. It may be a part of group or artifact name.
      * @param start The start index of the search.

--- a/src/test/java/com/github/aistomin/maven/browser/MavenCentralTest.java
+++ b/src/test/java/com/github/aistomin/maven/browser/MavenCentralTest.java
@@ -110,6 +110,70 @@ final class MavenCentralTest {
     }
 
     /**
+     * Check that we can search using a string which contains a space.
+     *
+     * @throws Exception If something went wrong.
+     */
+    @Test
+    void testFindArtifactsWithSpace() throws Exception {
+        Assertions.assertFalse(
+            new MavenCentral().findArtifacts("guice inject").isEmpty()
+        );
+    }
+
+    /**
+     * Check that we can search using the Maven search API field syntax, which
+     * contains characters that are not allowed in a URL.
+     *
+     * @throws Exception If something went wrong.
+     */
+    @Test
+    void testFindArtifactsWithFieldQuery() throws Exception {
+        final String group = this.mine.group().name();
+        final List<MvnArtifact> found = new MavenCentral().findArtifacts(
+            String.format("g:\"%s\"", group)
+        );
+        Assertions.assertFalse(found.isEmpty());
+        Assertions.assertTrue(found.contains(this.mine));
+        found.forEach(
+            artifact ->
+                Assertions.assertEquals(group, artifact.group().name())
+        );
+    }
+
+    /**
+     * Check that the request parameters can not be injected via the search
+     * string.
+     *
+     * @throws Exception If something went wrong.
+     */
+    @Test
+    void testFindArtifactsIgnoresInjectedParameters() throws Exception {
+        Assertions.assertTrue(
+            new MavenCentral()
+                .findArtifacts("a&rows=1000", 0, MavenCentralTest.FIVE)
+                .size() <= MavenCentralTest.FIVE
+        );
+    }
+
+    /**
+     * Check that an artifact whose coordinates contain a character which is not
+     * allowed in a URL fails with {@link MvnException} rather than with an
+     * unchecked exception.
+     */
+    @Test
+    void testFindVersionsWithSpaceInCoordinates() {
+        Assertions.assertThrows(
+            MvnException.class,
+            () -> new MavenCentral().findVersions(
+                new MavenArtifact(
+                    new MavenGroup("com.github aistomin"), "jenkins sdk"
+                )
+            )
+        );
+    }
+
+    /**
      * Check that we correctly throw exceptions if something went wrong.
      */
     @Test


### PR DESCRIPTION
`MavenCentral.findArtifacts` interpolated the raw search string into the query
URL. As a result:

- a space or a quote (e.g. `guice inject`, or the Search API's own documented
  syntax `g:"com.github.aistomin"`) made `URI.create` throw an unchecked
  `IllegalArgumentException`, bypassing the declared `throws MvnException`
  contract;
- a `+` was decoded as a space by the server, silently searching for something
  else;
- an `&` truncated the query and injected request parameters —
  `findArtifacts("a&rows=1000", 0, 5)` actually returned 20 rows.

The `q` value is now encoded with `URLEncoder.encode(str, StandardCharsets.UTF_8)`.

`findVersions` built its repository path the same way, so it is hardened too:
the path is percent-encoded via the multi-argument `URI` constructor (the right
tool for path segments — `URLEncoder` would turn a space into `+` rather than
`%20`). Its checked `URISyntaxException` is wrapped in `MvnException` alongside
the other failures there, so that call also stays inside its declared contract.

Behaviour change: callers who worked around the bug by passing a pre-encoded
search string will now have it encoded a second time. The raw-string contract is
the documented one, so this is the intended direction.

Tests added to `MavenCentralTest`, all hitting the real Maven Central APIs like
the rest of that class:

- search with a space returns results;
- search with the `g:"..."` field syntax returns only that group's artifacts;
- `findArtifacts("a&rows=1000", 0, 5)` respects the requested row count;
- `findVersions` on coordinates containing a space fails with `MvnException`
  rather than an unchecked exception.

`mvn clean install package javadoc:javadoc` passes on JDK 21 (Checkstyle clean,
JaCoCo coverage checks met).

Closes #511