### PR TITLE
fix(#512): compare versions using maven's ordering rules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <version>3.9.16</version>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <version>${junitVersion}</version>

--- a/src/main/java/com/github/aistomin/maven/browser/MavenCentral.java
+++ b/src/main/java/com/github/aistomin/maven/browser/MavenCentral.java
@@ -17,7 +17,6 @@ package com.github.aistomin.maven.browser;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.module.ModuleDescriptor.Version;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
@@ -30,6 +29,7 @@ import java.util.stream.Collectors;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import org.apache.commons.io.IOUtils;
+import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -270,7 +270,9 @@ public final class MavenCentral implements MvnRepo {
     }
 
     /**
-     * Check if one version is bigger than another.
+     * Check if one version is bigger than another. The versions are ordered
+     * using Maven's own rules, so any version string can be compared and the
+     * qualifiers are ranked the way Maven ranks them.
      *
      * @param first Version A.
      * @param second Version B.
@@ -281,7 +283,7 @@ public final class MavenCentral implements MvnRepo {
         final MvnArtifactVersion first,
         final MvnArtifactVersion second
     ) {
-        return Version.parse(first.name())
-            .compareTo(Version.parse(second.name())) > 0;
+        return new ComparableVersion(first.name())
+            .compareTo(new ComparableVersion(second.name())) > 0;
     }
 }

--- a/src/test/java/com/github/aistomin/maven/browser/MavenCentralTest.java
+++ b/src/test/java/com/github/aistomin/maven/browser/MavenCentralTest.java
@@ -52,6 +52,15 @@ final class MavenCentralTest {
     );
 
     /**
+     * Guava. Its version history contains both non-numeric versions
+     * (r03 ... r09) and qualified ones (10.0-rc1), which is exactly what the
+     * version comparison needs to be checked against.
+     */
+    private final MvnArtifact guava = new MavenArtifact(
+        new MavenGroup("com.google.guava"), "guava"
+    );
+
+    /**
      * The list of the versions of my artifact which we use for this test.
      */
     private final List<String> vers = Arrays.asList(
@@ -294,6 +303,40 @@ final class MavenCentralTest {
     }
 
     /**
+     * Check that a version which does not start with a digit does not break
+     * the search of the newer versions.
+     *
+     * @throws Exception If something went wrong.
+     */
+    @Test
+    void testFindVersionsNewerThanNonNumericVersion() throws Exception {
+        final List<String> newer = names(
+            new MavenCentral().findVersionsNewerThan(this.guavaVersion("r09"))
+        );
+        Assertions.assertFalse(newer.isEmpty());
+        Assertions.assertTrue(newer.contains("10.0"));
+        Assertions.assertFalse(newer.contains("r03"));
+        Assertions.assertFalse(newer.contains("r09"));
+    }
+
+    /**
+     * Check that the versions are ordered using Maven's rules: a release
+     * candidate is older than the release, and a non-numeric version is older
+     * than a numeric one.
+     *
+     * @throws Exception If something went wrong.
+     */
+    @Test
+    void testFindVersionsOlderThanQualifiedVersion() throws Exception {
+        final List<String> older = names(
+            new MavenCentral().findVersionsOlderThan(this.guavaVersion("10.0"))
+        );
+        Assertions.assertTrue(older.contains("10.0-rc1"));
+        Assertions.assertTrue(older.contains("r09"));
+        Assertions.assertFalse(older.contains("10.0.1"));
+    }
+
+    /**
      * Check that we correctly find the versions which are newer than provided
      * one.
      *
@@ -323,6 +366,30 @@ final class MavenCentralTest {
                 )
             );
         }
+    }
+
+    /**
+     * Create a version of Guava.
+     *
+     * @param name The version's name.
+     * @return The version.
+     */
+    private MvnArtifactVersion guavaVersion(final String name) {
+        return new MavenArtifactVersion(
+            this.guava, name, MvnPackagingType.JAR, System.currentTimeMillis()
+        );
+    }
+
+    /**
+     * Extract the names of the versions.
+     *
+     * @param versions The versions.
+     * @return The names of the versions.
+     */
+    private static List<String> names(
+        final List<MvnArtifactVersion> versions
+    ) {
+        return versions.stream().map(MvnArtifactVersion::name).toList();
     }
 
     /**


### PR DESCRIPTION
`findVersionsNewerThan` / `findVersionsOlderThan` compared versions with
`java.lang.module.ModuleDescriptor.Version`, which has two problems.

**1. Unchecked crash on real artifacts.** `Version.parse` rejects any version
that does not start with a digit. A single such version anywhere in an
artifact's history made both methods throw an unchecked
`IllegalArgumentException`, bypassing the declared `throws MvnException`
contract. This is easy to hit: `com.google.guava:guava` has `r03 … r09`, so the
search was broken for *every* Guava version.

**2. JPMS ordering instead of Maven's.** Comparing the two implementations over
the real version histories of maven-artifact, slf4j-api, commons-io,
junit-jupiter-api, maven-browser, spring-core and checkstyle produced no
disagreements — JPMS already ranks `alpha < beta < rc < release` and
`1.0-SNAPSHOT < 1.0` correctly. The genuine divergences are narrow but real:

| pair | JPMS (before) | Maven (after) |
| --- | --- | --- |
| `1.0.0.RELEASE` vs `1.0.0` | RELEASE is newer | equal |
| `2.0` vs `2.0-1` | `2.0` is newer | `2.0-1` is newer (build number) |

## The change

`ComparableVersion` from `org.apache.maven:maven-artifact` (3.9.16, one
transitive dependency: `plexus-utils`) replaces `ModuleDescriptor.Version`. It
never throws — every version string is comparable — and it is what Maven itself
orders versions with.

## Compatibility

The comparison lives in a private static method, so no signature, return type or
result ordering changes; the returned list keeps its newest-first order.
`maven-dependencies-analyser` was built against this branch as an end-to-end
check: its 8 tests pass and its reported findings are byte-identical to a run
against the released `maven-browser` 5.0.

Downstream users should expect one intended behavioural change: dependencies
whose history contains a non-numeric version were previously *skipped* by the
analyser (it catches the crash and logs "Can not analyse …") and will now be
analysed properly — which may surface outdated dependencies that were silently
passed over before.

The unrelated `IllegalStateException` thrown when the current version is not
found in the repository is deliberately left alone; it is out of scope here.

## Tests

Two cases added to `MavenCentralTest`, both against real Guava, whose history
contains both halves of the issue (`r03 … r09` and `10.0-rc1` before `10.0`):

- `findVersionsNewerThan(guava r09)` returns results, contains `10.0`, excludes
  `r03` and `r09` — previously an unchecked `IllegalArgumentException`;
- `findVersionsOlderThan(guava 10.0)` contains `10.0-rc1` and `r09`, excludes
  `10.0.1` — covering rc-before-release and non-numeric ordering at once.

`mvn clean install package javadoc:javadoc` passes on JDK 21 (Checkstyle clean,
duplicate-finder clean, JaCoCo coverage checks met, 30 tests green).

Closes #512