### PR TITLE
ci(#513): replace the codecov bash uploader with codecov-action

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -30,4 +30,8 @@ jobs:
     - name: Build with Maven
       run: mvn clean install package javadoc:javadoc
     - name: Publish Codecov
-      run: bash <(curl -s https://codecov.io/bash)
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./target/site/jacoco/jacoco.xml
+        disable_search: true


### PR DESCRIPTION
The CI workflow uploaded coverage by piping an unpinned third-party script
straight into bash on every run:

```yaml
- name: Publish Codecov
  run: bash <(curl -s https://codecov.io/bash)
```

**Security.** That is the uploader that was modified to exfiltrate CI
environment variables in the April 2021 supply-chain attack, fetched fresh and
executed unverified on every build.

**It has not worked for years.** Codecov sunset the bash uploader in 2021.
codecov.io still lists this repository as active, but its last received
coverage is dated `2024-05-30` — so the README badge has been showing a stale
95% ever since, while the step quietly did nothing.

## The change

```yaml
- name: Publish Codecov
  uses: codecov/codecov-action@v5
  with:
    token: ${{ secrets.CODECOV_TOKEN }}
    files: ./target/site/jacoco/jacoco.xml
    disable_search: true
```

- `files` points at the JaCoCo XML report the build already writes — no pom
  changes were needed.
- `disable_search: true` stops the Codecov CLI from also scanning the tree and
  picking up `jacoco.csv` or other stray reports.
- `fail_ci_if_error` is left at its default (`false`), so a Codecov outage or
  rate limit cannot break a build whose real coverage gate is JaCoCo's own 90%
  `jacoco:check` at `verify`.

The `CODECOV_TOKEN` repository secret has been added. `release.yml` and the
README badge are untouched — the badge URL still resolves and will refresh by
itself once the first upload lands on `master`.

## Verification

Nothing here is exercised by the Maven build, so the real check is this PR's own
CI run: the Codecov step should succeed and codecov.io's `updatestamp` should
move off `2024-05-30`.

Closes #513