### PR TITLE
feat(#514): add timeouts to the network calls in MavenCentral

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,11 +45,6 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>2.22.0</version>
-        </dependency>
-        <dependency>
             <groupId>com.googlecode.json-simple</groupId>
             <artifactId>json-simple</artifactId>
             <version>1.1.1</version>

--- a/src/main/java/com/github/aistomin/maven/browser/MavenCentral.java
+++ b/src/main/java/com/github/aistomin/maven/browser/MavenCentral.java
@@ -17,10 +17,16 @@ package com.github.aistomin.maven.browser;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -28,7 +34,6 @@ import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import org.apache.commons.io.IOUtils;
 import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
@@ -60,6 +65,21 @@ public final class MavenCentral implements MvnRepo {
     public static final String ENCODING = "UTF-8";
 
     /**
+     * Default time we wait until the connection to the repository is
+     * established.
+     */
+    public static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(10);
+
+    /**
+     * Default time we wait for the repository's response. Maven Central
+     * usually answers in a fraction of a second, but it is known to stall for
+     * a minute and more from time to time, that's why the default is that
+     * generous. Use the parametrised ctor if your use case needs to give up
+     * earlier.
+     */
+    public static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(120);
+
+    /**
      * The Maven repository base URL for fetching metadata.
      */
     private final String repo;
@@ -70,14 +90,46 @@ public final class MavenCentral implements MvnRepo {
     private final String search;
 
     /**
+     * The HTTP client which we use to talk to the repository.
+     */
+    private final HttpClient client;
+
+    /**
+     * The time we wait for the repository's response.
+     */
+    private final Duration response;
+
+    /**
      * Parametrised ctor.
+     *
+     * @param repository The Maven repo base URL for fetching metadata.
+     * @param searchApi The Maven search API URL.
+     * @param connect The time we wait until the connection is established.
+     * @param timeout The time we wait for the repository's response.
+     */
+    public MavenCentral(
+        final String repository,
+        final String searchApi,
+        final Duration connect,
+        final Duration timeout
+    ) {
+        this.repo = repository;
+        this.search = searchApi;
+        this.response = timeout;
+        this.client = HttpClient.newBuilder()
+            .connectTimeout(connect)
+            .followRedirects(HttpClient.Redirect.NORMAL)
+            .build();
+    }
+
+    /**
+     * Parametrised ctor. The default timeouts are used.
      *
      * @param repository The Maven repo base URL for fetching metadata.
      * @param searchApi The Maven search API URL.
      */
     public MavenCentral(final String repository, final String searchApi) {
-        this.repo = repository;
-        this.search = searchApi;
+        this(repository, searchApi, CONNECT_TIMEOUT, REQUEST_TIMEOUT);
     }
 
     /**
@@ -102,22 +154,23 @@ public final class MavenCentral implements MvnRepo {
         final String str, final Integer start, final Integer rows
     ) throws MvnException {
         try {
-            final String result = IOUtils.toString(
-                URI.create(
-                    String.format(
-                        "%s?q=%s&start=%d&rows=%d&wt=json",
-                        this.search,
-                        URLEncoder.encode(str, StandardCharsets.UTF_8),
-                        start,
-                        rows
-                    )
+            final String result = this.get(
+                String.format(
+                    "%s?q=%s&start=%d&rows=%d&wt=json",
+                    this.search,
+                    URLEncoder.encode(str, StandardCharsets.UTF_8),
+                    start,
+                    rows
                 ),
-                ENCODING
+                HttpResponse.BodyHandlers.ofString(Charset.forName(ENCODING))
             );
             return parseJsonResponse(result)
                 .stream()
                 .map(MavenArtifact::new)
                 .collect(Collectors.toList());
+        } catch (final InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new MvnException(exception);
         } catch (final ParseException | IOException exception) {
             throw new MvnException(exception);
         }
@@ -150,7 +203,7 @@ public final class MavenCentral implements MvnRepo {
                 ).toASCIIString()
             );
             final List<String> allVersions = parseMetadataXml(
-                URI.create(url).toURL().openStream()
+                this.get(url, HttpResponse.BodyHandlers.ofInputStream())
             );
             final int endIndex = Math.min(start + rows, allVersions.size());
             final List<String> pagedVersions =
@@ -164,6 +217,9 @@ public final class MavenCentral implements MvnRepo {
                     )
                 )
                 .collect(Collectors.toList());
+        } catch (final InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new MvnException(exception);
         } catch (final IOException | ParserConfigurationException
             | SAXException | URISyntaxException exception) {
             throw new MvnException(exception);
@@ -189,6 +245,37 @@ public final class MavenCentral implements MvnRepo {
             (ver, current) ->
                 isFirstVersionBiggerThanSecondVersion(current, ver)
         );
+    }
+
+    /**
+     * Send a GET request to the repository and read the response's body.
+     *
+     * @param url The URL we read from.
+     * @param handler The handler which converts the response's body.
+     * @param <T> The type of the response's body.
+     * @return The response's body.
+     * @throws IOException If the request failed or the repository answered
+     *  with an unsuccessful status.
+     * @throws InterruptedException If the request was interrupted.
+     */
+    private <T> T get(
+        final String url, final HttpResponse.BodyHandler<T> handler
+    ) throws IOException, InterruptedException {
+        final HttpResponse<T> answer = this.client.send(
+            HttpRequest.newBuilder(URI.create(url))
+                .timeout(this.response)
+                .GET()
+                .build(),
+            handler
+        );
+        final int status = answer.statusCode();
+        if (status < HttpURLConnection.HTTP_OK
+            || status >= HttpURLConnection.HTTP_MULT_CHOICE) {
+            throw new IOException(
+                String.format("Got HTTP %d reading %s.", status, url)
+            );
+        }
+        return answer.body();
     }
 
     /**

--- a/src/test/java/com/github/aistomin/maven/browser/MavenArtifactTest.java
+++ b/src/test/java/com/github/aistomin/maven/browser/MavenArtifactTest.java
@@ -15,11 +15,11 @@
  */
 package com.github.aistomin.maven.browser;
 
-import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.UUID;
-import org.apache.commons.io.FileUtils;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.junit.jupiter.api.Assertions;
@@ -48,11 +48,11 @@ final class MavenArtifactTest {
             "jenkins-sdk",
             new MavenArtifact(
                 (JSONObject) new JSONParser().parse(
-                    FileUtils.readFileToString(
-                        new File(
+                    Files.readString(
+                        Path.of(
                             Thread.currentThread().getContextClassLoader()
-                                .getResource("sample.json").getFile()
-                        ), "UTF-8"
+                                .getResource("sample.json").toURI()
+                        )
                     )
                 )
             ).name()

--- a/src/test/java/com/github/aistomin/maven/browser/MavenArtifactVersionTest.java
+++ b/src/test/java/com/github/aistomin/maven/browser/MavenArtifactVersionTest.java
@@ -15,13 +15,13 @@
  */
 package com.github.aistomin.maven.browser;
 
-import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
 import java.util.UUID;
-import org.apache.commons.io.FileUtils;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.junit.jupiter.api.Assertions;
@@ -61,11 +61,11 @@ final class MavenArtifactVersionTest {
         Assertions.assertEquals(type, modern.packaging());
         final MavenArtifactVersion json = new MavenArtifactVersion(
             (JSONObject) new JSONParser().parse(
-                FileUtils.readFileToString(
-                    new File(
+                Files.readString(
+                    Path.of(
                         Thread.currentThread().getContextClassLoader()
-                            .getResource("sample.json").getFile()
-                    ), "UTF-8"
+                            .getResource("sample.json").toURI()
+                    )
                 )
             )
         );

--- a/src/test/java/com/github/aistomin/maven/browser/MavenCentralTest.java
+++ b/src/test/java/com/github/aistomin/maven/browser/MavenCentralTest.java
@@ -15,6 +15,9 @@
  */
 package com.github.aistomin.maven.browser;
 
+import java.net.ServerSocket;
+import java.net.http.HttpTimeoutException;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -337,6 +340,46 @@ final class MavenCentralTest {
     }
 
     /**
+     * Check that the search does not hang forever if the repository accepts
+     * the connection but never answers.
+     *
+     * @throws Exception If something went wrong.
+     */
+    @Test
+    void testFindArtifactsTimesOut() throws Exception {
+        try (ServerSocket silent = new ServerSocket(0)) {
+            final MvnRepo mvn = MavenCentralTest.impatient(silent);
+            Assertions.assertInstanceOf(
+                HttpTimeoutException.class,
+                Assertions.assertThrows(
+                    MvnException.class,
+                    () -> mvn.findArtifacts("guice")
+                ).getCause()
+            );
+        }
+    }
+
+    /**
+     * Check that the versions search does not hang forever if the repository
+     * accepts the connection but never answers.
+     *
+     * @throws Exception If something went wrong.
+     */
+    @Test
+    void testFindVersionsTimesOut() throws Exception {
+        try (ServerSocket silent = new ServerSocket(0)) {
+            final MvnRepo mvn = MavenCentralTest.impatient(silent);
+            Assertions.assertInstanceOf(
+                HttpTimeoutException.class,
+                Assertions.assertThrows(
+                    MvnException.class,
+                    () -> mvn.findVersions(this.mine)
+                ).getCause()
+            );
+        }
+    }
+
+    /**
      * Check that we correctly find the versions which are newer than provided
      * one.
      *
@@ -366,6 +409,23 @@ final class MavenCentralTest {
                 )
             );
         }
+    }
+
+    /**
+     * Create a repository which talks to the given socket and gives up almost
+     * immediately. The socket is never accepted, so the connection is
+     * established by the OS and the "server" stays silent forever.
+     *
+     * @param silent The socket which never answers.
+     * @return The repository.
+     */
+    private static MvnRepo impatient(final ServerSocket silent) {
+        final String url = String.format(
+            "http://127.0.0.1:%d", silent.getLocalPort()
+        );
+        return new MavenCentral(
+            url, url, Duration.ofSeconds(1), Duration.ofSeconds(1)
+        );
     }
 
     /**

--- a/src/test/java/com/github/aistomin/maven/browser/MavenGroupTest.java
+++ b/src/test/java/com/github/aistomin/maven/browser/MavenGroupTest.java
@@ -15,11 +15,11 @@
  */
 package com.github.aistomin.maven.browser;
 
-import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.UUID;
-import org.apache.commons.io.FileUtils;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.junit.jupiter.api.Assertions;
@@ -41,11 +41,11 @@ final class MavenGroupTest {
     void testConstruct() throws Exception {
         final MvnGroup group = new MavenGroup(
             (JSONObject) new JSONParser().parse(
-                FileUtils.readFileToString(
-                    new File(
+                Files.readString(
+                    Path.of(
                         Thread.currentThread().getContextClassLoader()
-                            .getResource("sample.json").getFile()
-                    ), "UTF-8"
+                            .getResource("sample.json").toURI()
+                    )
                 )
             )
         );


### PR DESCRIPTION
Both network calls in `MavenCentral` used JDK defaults with no connect or read
timeout — `IOUtils.toString(URI, encoding)` for the search API and
`URI.create(url).toURL().openStream()` for `maven-metadata.xml`. A repository
that accepts the connection and then says nothing blocked the calling thread
forever, with no way for a library user to cancel it.

## The change

Both call sites now go through JDK 21's `java.net.http.HttpClient`:

- **connect timeout 10s** (`MavenCentral.CONNECT_TIMEOUT`)
- **request timeout 120s** (`MavenCentral.REQUEST_TIMEOUT`)
- a new ctor for callers who want their own values, with the existing two
  delegating to it:

```java
public MavenCentral(String repository, String searchApi, Duration connect, Duration timeout)
```

### Why 120s and not something tighter

Measuring the live search API while working on this, the same query returned in
`0.15s`, `20.9s`, `30.6s`, and once hit a 90s ceiling — on both HTTP/1.1 and
HTTP/2, so it is the service, not the protocol. A 60s default was tried first and
made this repository's own `testFindArtifacts` fail against a healthy Maven
Central. The point of the issue is to bound an unbounded hang, not to convert
Maven Central's normal slowness into errors.

## Behaviour deliberately preserved

`HttpClient` differs from the old code in three ways that would otherwise have
changed behaviour silently:

| | `openStream()` / `IOUtils` | `HttpClient` default | What this PR does |
| --- | --- | --- | --- |
| Redirects | followed | `Redirect.NEVER` | `followRedirects(NORMAL)` |
| 4xx/5xx | throws `IOException` | ordinary response | explicit status check, throws `IOException` |
| Interrupt | n/a | `InterruptedException` | restores the interrupt flag, wraps in `MvnException` |

The status check is what keeps `testFindVersionsWithSpaceInCoordinates` (404) and
`testExceptions` (dead host) throwing `MvnException` for the same reasons as
before.

**One narrowing worth noting:** only `http` and `https` work now. The repository
and search URLs are constructor-injectable, and `openStream()` accepted any
protocol, so a `file:` URL would previously have worked. Nothing in the tests or
examples used one.

The client is held per `MavenCentral` instance and not closed. It is
`AutoCloseable` in Java 21, but making `MavenCentral` closeable would change how
every caller uses it; the JDK frees the client's resources once it is unreachable.

## commons-io dropped

The issue said the search call was the only usage — it was not:
`MavenGroupTest`, `MavenArtifactTest` and `MavenArtifactVersionTest` all used
`FileUtils.readFileToString`. Those three now use `Files.readString`, so the
dependency is gone completely rather than demoted to test scope. Compile scope is
now just `json-simple` and `maven-artifact`.

## Tests

Two new cases, both fully offline and deterministic: open a `ServerSocket` and
never `accept()` it. The OS completes the TCP handshake from the backlog queue, so
the connection succeeds and the "server" then stays silent — exactly the hang the
issue describes. With 1s timeouts, `findArtifacts` and `findVersions` each throw
`MvnException` caused by `HttpTimeoutException` instead of blocking.

`mvn clean install package javadoc:javadoc` passes on JDK 21: 32 tests, Checkstyle
clean, JaCoCo coverage checks met.

Downstream check, as on #512: `maven-dependencies-analyser` built against this
snapshot passes its 8 tests and reports findings byte-identical to a run against
the released `maven-browser` 5.0. It does not use `commons-io` directly, so
dropping it costs nothing there.

Closes #514