### PR TITLE
fix(#442): generate javadoc only once per maven build

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,7 +28,7 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven
-      run: mvn clean install package javadoc:javadoc
+      run: mvn clean install
     - name: Publish Codecov
       uses: codecov/codecov-action@v5
       with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ browsing Maven Central. It is published to Maven Central as
 
 ```bash
 # Full build — run this before submitting any PR (per README contribution guidelines)
-mvn clean install package javadoc:javadoc
+mvn clean install
 
 # Tests only
 mvn test
@@ -222,7 +222,7 @@ to push.
    The verification command is the full Maven build:
 
    ```bash
-   mvn clean install package javadoc:javadoc
+   mvn clean install
    ```
 
    It needs JDK 21 and network access (`MavenCentralTest` calls the real Maven Central

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ your changes and merge them to the master branch if they meet our guidelines.
 To avoid frustration, before sending us your pull request please run the full Maven build:
 
 ```
-$ mvn clean install package javadoc:javadoc
+$ mvn clean install
 ```
 
 Keep in mind our [system requirements](#system-requirements).

--- a/pom.xml
+++ b/pom.xml
@@ -107,43 +107,6 @@
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>${javadocPluginVersion}</version>
-                        <configuration>
-                            <source>21</source>
-                            <doclint>none</doclint>
-                            <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</additionalJOption>
-                            <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</additionalJOption>
-                            <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</additionalJOption>
-                            <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</additionalJOption>
-                            <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</additionalJOption>
-                            <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</additionalJOption>
-                            <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</additionalJOption>
-                            <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</additionalJOption>
-                            <additionalJOption>--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</additionalJOption>
-                            <tags>
-                                <tag>
-                                    <name>checkstyle</name>
-                                    <placement>X</placement>
-                                </tag>
-                                <tag>
-                                    <name>todo</name>
-                                    <placement>a</placement>
-                                    <head>TODOs:</head>
-                                </tag>
-                            </tags>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
                         <version>3.2.8</version>
                         <executions>


### PR DESCRIPTION
`mvn clean install package javadoc:javadoc` ran the whole default lifecycle twice —
`install` already includes `package`, so everything from `checkstyle:check` to
`javadoc:jar` was executed a second time — and then generated the javadoc a third
time through the `javadoc:javadoc` report goal.

The build command is now `mvn clean install` in `README.md`, the `maven.yml` CI
workflow and `CLAUDE.md`. Javadoc runs exactly once, through the `attach-javadocs`
execution bound to `package` — the same goal and configuration the release uses, so
every local build and every CI run keeps testing the release javadoc path.

The `release` profile re-declared `maven-javadoc-plugin` with a byte-identical copy
of the base build's configuration and its `attach-javadocs` execution. Profile
plugins merge with base plugins by `groupId:artifactId`, so the copy was redundant
and is removed.

Verified:
- `mvn clean install` on JDK 21: `BUILD SUCCESS`, 32 tests pass, exactly one
  `javadoc:3.12.0:jar (attach-javadocs)` in the log, and
  `target/maven-browser-5.2-SNAPSHOT-javadoc.jar` is still produced.
- `help:effective-pom -P release` compared structurally before and after the pom
  edit: identical plugin set, identical configuration and executions, with
  `attach-javadocs` and the full javadoc configuration still present. Only the
  declaration order shifts, which has no effect on the release build.

Closes #442