### PR TITLE
fix(#515): harden the maven-metadata.xml parsing against xxe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,8 +127,8 @@ Every issue must have all three of:
    ```
 
 2. **Assignee `aistomin`.**
-3. **The highest-numbered open milestone** (as of milestone 15 that is `Version 5.1`).
-   Resolve it at creation time rather than hardcoding:
+3. **The highest-numbered open milestone.** Never hardcode it — it moves with every
+   release, so resolve it at creation time:
 
    ```bash
    gh api repos/aistomin/maven-browser/milestones \

--- a/src/main/java/com/github/aistomin/maven/browser/MavenCentral.java
+++ b/src/main/java/com/github/aistomin/maven/browser/MavenCentral.java
@@ -80,6 +80,15 @@ public final class MavenCentral implements MvnRepo {
     public static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(120);
 
     /**
+     * The XML parser feature which forbids a DTD in the parsed document. A
+     * legitimate maven-metadata.xml never contains one, so forbidding it costs
+     * us nothing and takes away the ground under both XXE and entity
+     * expansion attacks: neither works without a DTD.
+     */
+    private static final String NO_DOCTYPE =
+        "http://apache.org/xml/features/disallow-doctype-decl";
+
+    /**
      * The Maven repository base URL for fetching metadata.
      */
     private final String repo;
@@ -334,6 +343,11 @@ public final class MavenCentral implements MvnRepo {
     /**
      * Parse maven-metadata.xml to extract a versions list.
      * Returns versions in descending order (newest first).
+     * The repository URL is a public constructor parameter, so the answer we
+     * parse here is not necessarily trustworthy. The parser is therefore
+     * hardened before it is used: a document with a DTD is rejected instead
+     * of being parsed, and neither external entities nor XInclude are
+     * resolved.
      *
      * @param input The input stream of maven-metadata.xml.
      * @return The list of version strings, newest first.
@@ -344,9 +358,12 @@ public final class MavenCentral implements MvnRepo {
     private static List<String> parseMetadataXml(
         final InputStream input
     ) throws ParserConfigurationException, SAXException, IOException {
-        final Document doc = DocumentBuilderFactory.newInstance()
-            .newDocumentBuilder()
-            .parse(input);
+        final DocumentBuilderFactory factory =
+            DocumentBuilderFactory.newInstance();
+        factory.setFeature(NO_DOCTYPE, true);
+        factory.setXIncludeAware(false);
+        factory.setExpandEntityReferences(false);
+        final Document doc = factory.newDocumentBuilder().parse(input);
         final NodeList versionNodes = doc.getElementsByTagName("version");
         final List<String> versions = new ArrayList<>(versionNodes.getLength());
         for (int i = 0; i < versionNodes.getLength(); i++) {

--- a/src/test/java/com/github/aistomin/maven/browser/MavenCentralTest.java
+++ b/src/test/java/com/github/aistomin/maven/browser/MavenCentralTest.java
@@ -15,8 +15,16 @@
  */
 package com.github.aistomin.maven.browser;
 
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.http.HttpTimeoutException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
@@ -24,6 +32,8 @@ import java.util.stream.IntStream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.xml.sax.SAXParseException;
 
 /**
  * The tests for {@link MavenCentral}.
@@ -380,6 +390,77 @@ final class MavenCentralTest {
     }
 
     /**
+     * Check that a metadata file which declares a DTD is rejected instead of
+     * being parsed. Such a file is the vehicle for XXE: the entity below
+     * points at a local file, and an unhardened parser would happily read it
+     * and hand its content back as a version name.
+     *
+     * @param dir The temporary directory with the "secret" file.
+     * @throws Exception If something went wrong.
+     */
+    @Test
+    void testFindVersionsRejectsMaliciousDoctype(
+        @TempDir final Path dir
+    ) throws Exception {
+        final Path secret = dir.resolve("secret.txt");
+        Files.writeString(secret, "top-secret");
+        final HttpServer server = MavenCentralTest.serving(
+            String.join(
+                "",
+                "<?xml version=\"1.0\"?>",
+                "<!DOCTYPE metadata [",
+                String.format("<!ENTITY xxe SYSTEM \"%s\">", secret.toUri()),
+                "]>",
+                "<metadata><versioning><versions>",
+                "<version>&xxe;</version>",
+                "</versions></versioning></metadata>"
+            )
+        );
+        try {
+            final MvnRepo mvn = MavenCentralTest.talkingTo(server);
+            final Throwable cause = Assertions.assertThrows(
+                MvnException.class,
+                () -> mvn.findVersions(this.mine)
+            ).getCause();
+            Assertions.assertInstanceOf(SAXParseException.class, cause);
+            Assertions.assertTrue(
+                cause.getMessage().contains("DOCTYPE"), cause.getMessage()
+            );
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    /**
+     * Check that hardening the parser did not break the parsing of an
+     * ordinary metadata file.
+     *
+     * @throws Exception If something went wrong.
+     */
+    @Test
+    void testFindVersionsParsesPlainMetadata() throws Exception {
+        final HttpServer server = MavenCentralTest.serving(
+            String.join(
+                "",
+                "<?xml version=\"1.0\"?>",
+                "<metadata><versioning><versions>",
+                "<version>1.0</version><version>2.0</version>",
+                "</versions></versioning></metadata>"
+            )
+        );
+        try {
+            Assertions.assertEquals(
+                Arrays.asList("2.0", "1.0"),
+                MavenCentralTest.names(
+                    MavenCentralTest.talkingTo(server).findVersions(this.mine)
+                )
+            );
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    /**
      * Check that we correctly find the versions which are newer than provided
      * one.
      *
@@ -426,6 +507,48 @@ final class MavenCentralTest {
         return new MavenCentral(
             url, url, Duration.ofSeconds(1), Duration.ofSeconds(1)
         );
+    }
+
+    /**
+     * Create a repository which reads its metadata from the given local
+     * server.
+     *
+     * @param server The server which answers the requests.
+     * @return The repository.
+     */
+    private static MvnRepo talkingTo(final HttpServer server) {
+        final String url = String.format(
+            "http://127.0.0.1:%d", server.getAddress().getPort()
+        );
+        return new MavenCentral(url, url);
+    }
+
+    /**
+     * Start a local HTTP server which answers every request with the given
+     * body. The caller has to stop it.
+     *
+     * @param body The body of the answer.
+     * @return The started server.
+     * @throws IOException If the server can not be started.
+     */
+    private static HttpServer serving(final String body) throws IOException {
+        final byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        final HttpServer server = HttpServer.create(
+            new InetSocketAddress("127.0.0.1", 0), 0
+        );
+        server.createContext(
+            "/",
+            exchange -> {
+                exchange.sendResponseHeaders(
+                    HttpURLConnection.HTTP_OK, bytes.length
+                );
+                try (OutputStream out = exchange.getResponseBody()) {
+                    out.write(bytes);
+                }
+            }
+        );
+        server.start();
+        return server;
     }
 
     /**


### PR DESCRIPTION
`MavenCentral.parseMetadataXml` parsed `maven-metadata.xml` with a default
`DocumentBuilderFactory`, which resolves DTDs and external entities. The
repository URL is a public constructor parameter, so a repository other than
`repo1.maven.org` can answer with a metadata file whose entity points at a
local file or an internal URL (XXE → file disclosure and SSRF), or at a nest
of nested entities (expansion DoS).

This was not theoretical. Parsing the payload below with the old code returned
the content of the referenced file as a version name:

```
version node content = [top-secret]
```

The factory is now configured before use:

- `disallow-doctype-decl` = `true` — a document with a DTD is rejected outright
- `setXIncludeAware(false)`
- `setExpandEntityReferences(false)`

Both XXE and entity expansion need a DTD, and a legitimate `maven-metadata.xml`
never has one, so forbidding it costs nothing.

Two tests, both served by a local `HttpServer` on an ephemeral port so they need
no network:

- `testFindVersionsRejectsMaliciousDoctype` — a metadata file with a
  `<!DOCTYPE ... <!ENTITY xxe SYSTEM "file:...">>` pointing at a file in a JUnit
  `@TempDir` must produce an `MvnException` caused by a `SAXParseException` that
  mentions `DOCTYPE`.
- `testFindVersionsParsesPlainMetadata` — an ordinary metadata file still parses,
  newest version first.

The first test was checked to be discriminating: with `src/main` reverted it
fails with *"Expected MvnException to be thrown, but nothing was thrown"*, i.e.
the malicious document parsed cleanly.

`mvn clean install` on JDK 21: 0 Checkstyle violations, 34 tests pass (was 32),
`BUILD SUCCESS`.

Unrelated one-liner riding along: `CLAUDE.md` no longer names a concrete
milestone ("as of milestone 15 that is `Version 5.1`") in the issue-creation
rules, since `Version 5.1` is released and the `gh api` command directly below
resolves the current one anyway.

Closes #515