### PR TITLE
fix(#532): enable javadoc doclint and fail on its warnings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,10 @@ Notes on the build:
   violation. Rules are strict: mandatory Javadoc on all methods, fields, and types
   (including tests), line-length limits, naming rules, `final` parameters, etc. Match the
   existing files' Javadoc/comment style exactly or the build breaks before compiling.
+- Javadoc runs at `package` (the `attach-javadocs` execution) with `-Xdoclint:all` and
+  `failOnWarnings`, so a broken `{@link}`, a `@param` that does not match the signature or
+  invalid HTML in a comment **fails the build** — Checkstyle checks that Javadoc exists,
+  doclint checks that it is correct.
 - PMD, duplicate-finder, and `maven-dependencies-analyser` run at `verify`.
 - JaCoCo enforces **90% line coverage per package** (`jacoco:check`); new code needs tests.
 - Tests are JUnit 5 (Jupiter). `MavenCentralTest` hits the real Maven Central network APIs,

--- a/pom.xml
+++ b/pom.xml
@@ -281,16 +281,13 @@
                 <version>${javadocPluginVersion}</version>
                 <configuration>
                     <source>21</source>
-                    <doclint>none</doclint>
-                    <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</additionalJOption>
-                    <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</additionalJOption>
-                    <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</additionalJOption>
-                    <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</additionalJOption>
-                    <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</additionalJOption>
-                    <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</additionalJOption>
-                    <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</additionalJOption>
-                    <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</additionalJOption>
-                    <additionalJOption>--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</additionalJOption>
+                    <!-- Check the content of the Javadoc comments, not only
+                         their presence: broken references, tags which do not
+                         match the signature, invalid HTML. Warnings fail the
+                         build too, otherwise the warning-level findings would
+                         pile up unnoticed. -->
+                    <doclint>all</doclint>
+                    <failOnWarnings>true</failOnWarnings>
                     <tags>
                         <tag>
                             <name>checkstyle</name>


### PR DESCRIPTION
`<doclint>none</doclint>` switched off every javadoc content check. Checkstyle
enforces that javadoc *exists*; nothing checked that it is *correct*, so a broken
`{@link}`, a `@param` that no longer matches the signature, or invalid HTML in a
comment could be published to Maven Central unnoticed.

Javadoc now runs with `-Xdoclint:all` and `failOnWarnings`. The nine
`<additionalJOption>` entries are removed in the same pass.

### Verified

Same payload (`{@link NoSuchThing}` plus an unclosed `<b>`) in `MvnRepo`'s class
comment, `mvn clean package`:

| configuration | result |
| --- | --- |
| old (`doclint=none`) | `[WARNING] ... warning: reference not found: NoSuchThing`, the unclosed `<b>` not reported at all → **BUILD SUCCESS** |
| new (`doclint=all` + `failOnWarnings`) | `error: reference not found`, `error: element not closed: b` → **BUILD FAILURE** |

That warning line is also the case for `failOnWarnings`: javadoc was already
reporting the problem and nothing was listening.

`mvn clean install` on the branch: 0 Checkstyle violations, 34 tests pass, 0
javadoc errors or warnings, `BUILD SUCCESS`. The existing sources needed no
fixing — `-Xdoclint:all` is clean on them as they stand.

### Why the `<additionalJOption>` entries go

`additionalJOption` is a single-string parameter, not a list, so Maven kept only
the last of the nine. Dumping the real command line with `-Ddebug=true` showed
what javadoc actually received:

```
javadoc -J-Duser.language= -J-Duser.country= \
  --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED @options @packages
```

All eight `--add-exports=...` flags were silently discarded, and javadoc
generates the documentation with `doclint:all` without any of the nine. They
entered in the same commit as `doclint=none` (`474252b`, ticket #438), so they
were part of that workaround rather than a standing requirement.

`CLAUDE.md` gains a build-gate bullet documenting the new gate next to the
Checkstyle and JaCoCo ones.

Closes #532