### PR TITLE
fix(#523): print pmd violations via the plugin instead of sh -c cat

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,7 @@
                 <configuration>
                     <failurePriority>1</failurePriority>
                     <failOnViolation>true</failOnViolation>
+                    <printFailingErrors>true</printFailingErrors>
                 </configuration>
                 <executions>
                     <execution>
@@ -185,27 +186,6 @@
                         <goals>
                             <goal>check</goal>
                         </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>3.6.3</version>
-                <executions>
-                    <execution>
-                        <id>display-pmd-report</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <configuration>
-                            <executable>sh</executable>
-                            <arguments>
-                                <argument>-c</argument>
-                                <argument>cat ${project.build.directory}/pmd.xml</argument>
-                            </arguments>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
The `exec-maven-plugin` execution shelled out to `sh -c cat target/pmd.xml` to
display the PMD report. `sh` does not exist on Windows, so `mvn verify` failed
there with "Cannot run program sh", even though the README only asks
contributors for JDK 21 and Maven. It also dumped the raw XML on every build,
including builds with no violations at all.

`maven-pmd-plugin`'s own `printFailingErrors` prints the violations that fail
the check, in a readable form, on every platform — so the extra plugin is no
longer needed and its declaration is removed along with the execution.

Verified with a full `mvn clean install` (green). Since a passing build never
exercises the new output, it was also checked against a throwaway class with
two deliberate violations, which produced:

```
[WARNING] PMD Failure: ...PmdProbe:4 Rule:UnusedPrivateField Priority:3 Avoid unused private fields such as 'unused'..
[WARNING] PMD Failure: ...PmdProbe:8 Rule:UselessPureMethodCall Priority:3 Do not call pure method length if the result is not used..
```

Note that with `failurePriority=1` only priority-1 violations are printed;
lower-priority ones remain in `target/pmd.xml` instead of being dumped to the
console on every build.

Closes #523