### PR TITLE
build(#538): make LICENSE the single source of the copyright notice

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,10 @@ mvn test -Dtest=MavenCentralTest#methodName
 
 # Checkstyle alone (also runs automatically in the validate phase, so it fires on every build)
 mvn checkstyle:check
+
+# Rewrite the license header of every .java file from LICENSE. "validate" must
+# come first: that is the phase which extracts the header out of LICENSE.
+mvn validate license:format
 ```
 
 Notes on the build:
@@ -62,6 +66,33 @@ Notes on the build:
   violation. Rules are strict: mandatory Javadoc on all methods, fields, and types
   (including tests), line-length limits, naming rules, `final` parameters, etc. Match the
   existing files' Javadoc/comment style exactly or the build breaks before compiling.
+- **`LICENSE` is the only place the license text exists.** It is the verbatim 202-line
+  Apache 2.0 text from apache.org, which is what makes GitHub and license scanners detect
+  the project as `apache-2.0`. Never edit it, never reformat it, never trim it to the short
+  notice — that is what made this repo report `NOASSERTION` before.
+
+  The license header on every `.java` file is *derived* from it, not stored. `LICENSE`'s
+  last 13 lines are the "APPENDIX: How to apply the Apache License to your work" block;
+  `maven-antrun-plugin` extracts them at `validate`, de-indents them, fills the
+  `Copyright [yyyy] [name of copyright owner]` placeholder from `<inceptionYear>` and
+  `<organization>` in `pom.xml`, and writes `target/license-header.txt`.
+  `license-maven-plugin` then checks every `.java` header against it at `process-sources`
+  and **fails the build** on a drifted or missing header. Because the extraction reruns
+  every build, the two can never fall out of step: change `LICENSE` and the headers must be
+  regenerated or the build goes red.
+
+  So there are exactly three authored values — the Apache text in `LICENSE`, the year in
+  `<inceptionYear>`, the name in `<organization>` — and the notice itself is written nowhere.
+
+  It follows that you must never hand-edit a `.java` header (run `mvn validate
+  license:format`), and **never add a Checkstyle `Header`/`RegexpHeader` module or a
+  `conf/header.txt`-style template.** Those work by holding a second copy of the notice for
+  the first to be checked against; that copy is unchecked against `LICENSE` and will drift.
+
+  The year is fixed at **2019**, the year of first publication — never a range, never
+  bumped, and no automation to bump it. It carries no legal weight (copyright arises without
+  any notice under the Berne Convention), Apache's own boilerplate uses a single year, and a
+  constant notice is one that can never start failing on its own.
 - Javadoc runs at `package` (the `attach-javadocs` execution) with `-Xdoclint:all` and
   `failOnWarnings`, so a broken `{@link}`, a `@param` that does not match the signature or
   invalid HTML in a comment **fails the build** — Checkstyle checks that Javadoc exists,

--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,202 @@
-Copyright (c) 2019-2022, Istomin Andrei
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-http://www.apache.org/licenses/LICENSE-2.0
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![codecov](https://codecov.io/gh/aistomin/maven-browser/branch/master/graph/badge.svg)](https://codecov.io/gh/aistomin/maven-browser)
 [![Maven Central](https://img.shields.io/maven-central/v/com.github.aistomin/maven-browser)](https://central.sonatype.com/artifact/com.github.aistomin/maven-browser)
 [![javadoc](https://javadoc.io/badge2/com.github.aistomin/maven-browser/javadoc.svg)](https://javadoc.io/doc/com.github.aistomin/maven-browser)
+[![license](https://img.shields.io/github/license/aistomin/maven-browser)](https://github.com/aistomin/maven-browser/blob/master/LICENSE)
 
 This Java library allows you to search and browse Maven Central. It uses the
 [Maven Central Search API](https://search.maven.org/classic/#api) for artifact

--- a/conf/checkstyle.xml
+++ b/conf/checkstyle.xml
@@ -76,12 +76,13 @@
         <property name="message" value="Line has trailing spaces."/>
     </module>
 
-    <!-- Checks for Headers                                -->
-    <!-- See https://checkstyle.org/config_header.html   -->
-    <!-- <module name="Header"> -->
-    <!--   <property name="headerFile" value="${checkstyle.header.file}"/> -->
-    <!--   <property name="fileExtensions" value="java"/> -->
-    <!-- </module> -->
+    <!-- License headers are not checked here, and no Header or RegexpHeader  -->
+    <!-- module belongs in this file. Both compare a source file against a    -->
+    <!-- copy of the notice - inline here, or in a header template - and that -->
+    <!-- copy is a second place the text has to be maintained, with nothing   -->
+    <!-- checking it against LICENSE. The notice is instead extracted from    -->
+    <!-- LICENSE on every build and the headers are checked against that. See -->
+    <!-- the maven-antrun-plugin and license-maven-plugin setup in pom.xml.   -->
 
     <module name="TreeWalker">
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,19 @@
     <name>Maven Browser</name>
     <description>Java library which allows to search and browse the Maven artifacts.</description>
     <url>https://github.com/aistomin/maven-browser</url>
+    <!--
+        The year of first publication and the copyright holder. Apache's
+        license text carries these as the placeholders
+        "Copyright [yyyy] [name of copyright owner]", so they cannot come from
+        LICENSE and have to be stated once somewhere - here. The build fills
+        them into the license header of every .java file. The year is the year
+        of first publication: it is not a range and is never bumped.
+    -->
+    <inceptionYear>2019</inceptionYear>
+    <organization>
+        <name>Andrej Istomin</name>
+        <url>https://aistomin.com/</url>
+    </organization>
     <licenses>
         <license>
             <name>The Apache License, Version 2.0</name>
@@ -128,6 +141,92 @@
                     <source>21</source>
                     <target>21</target>
                 </configuration>
+            </plugin>
+            <!--
+                Derives the license header from LICENSE itself, so the notice
+                is never written down a second time.
+
+                LICENSE is the verbatim Apache 2.0 text. Its last 13 lines are
+                the "APPENDIX: How to apply the Apache License to your work"
+                boilerplate - Apache's own instruction for what every source
+                file should carry. Those lines, de-indented and with the
+                "Copyright [yyyy] [name of copyright owner]" placeholder
+                filled in from <inceptionYear> and <organization> above, are
+                exactly the header on every .java file.
+
+                This runs on every build and writes into target/, so the
+                extracted header cannot go stale: change LICENSE and the next
+                build compares the .java files against the new text.
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <id>extract-license-header</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <copy file="${project.basedir}/LICENSE"
+                                      tofile="${project.build.directory}/license-header.txt"
+                                      overwrite="true">
+                                    <filterchain>
+                                        <tailfilter lines="13"/>
+                                        <tokenfilter>
+                                            <trim/>
+                                        </tokenfilter>
+                                        <replacestring
+                                            from="Copyright [yyyy] [name of copyright owner]"
+                                            to="Copyright (c) ${project.inceptionYear} ${project.organization.name}"/>
+                                    </filterchain>
+                                </copy>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!--
+                Checks the header of every .java file against the notice
+                extracted from LICENSE above, and fails the build when a
+                header has drifted or is missing. Run
+                "mvn validate license:format" to rewrite the headers from
+                LICENSE; never edit a header by hand.
+
+                The check runs at process-sources rather than validate so the
+                extraction above has already happened, and so that
+                license:format is not blocked by the very check it exists to
+                satisfy.
+            -->
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>5.1.2</version>
+                <configuration>
+                    <licenseSets>
+                        <licenseSet>
+                            <header>${project.build.directory}/license-header.txt</header>
+                            <includes>
+                                <include>src/**/*.java</include>
+                            </includes>
+                        </licenseSet>
+                    </licenseSets>
+                    <mapping>
+                        <java>SLASHSTAR_STYLE</java>
+                    </mapping>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>check-license-headers</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/com/github/aistomin/maven/browser/MavenArtifact.java
+++ b/src/main/java/com/github/aistomin/maven/browser/MavenArtifact.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, Istomin Andrei
+ * Copyright (c) 2019 Andrej Istomin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/aistomin/maven/browser/MavenArtifactVersion.java
+++ b/src/main/java/com/github/aistomin/maven/browser/MavenArtifactVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, Istomin Andrei
+ * Copyright (c) 2019 Andrej Istomin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/aistomin/maven/browser/MavenCentral.java
+++ b/src/main/java/com/github/aistomin/maven/browser/MavenCentral.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, Istomin Andrei
+ * Copyright (c) 2019 Andrej Istomin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/aistomin/maven/browser/MavenDependency.java
+++ b/src/main/java/com/github/aistomin/maven/browser/MavenDependency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, Istomin Andrei
+ * Copyright (c) 2019 Andrej Istomin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/aistomin/maven/browser/MavenGroup.java
+++ b/src/main/java/com/github/aistomin/maven/browser/MavenGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, Istomin Andrei
+ * Copyright (c) 2019 Andrej Istomin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/aistomin/maven/browser/MvnArtifact.java
+++ b/src/main/java/com/github/aistomin/maven/browser/MvnArtifact.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, Istomin Andrei
+ * Copyright (c) 2019 Andrej Istomin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/aistomin/maven/browser/MvnArtifactVersion.java
+++ b/src/main/java/com/github/aistomin/maven/browser/MvnArtifactVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, Istomin Andrei
+ * Copyright (c) 2019 Andrej Istomin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/aistomin/maven/browser/MvnDependency.java
+++ b/src/main/java/com/github/aistomin/maven/browser/MvnDependency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, Istomin Andrei
+ * Copyright (c) 2019 Andrej Istomin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/aistomin/maven/browser/MvnException.java
+++ b/src/main/java/com/github/aistomin/maven/browser/MvnException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, Istomin Andrei
+ * Copyright (c) 2019 Andrej Istomin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/aistomin/maven/browser/MvnGroup.java
+++ b/src/main/java/com/github/aistomin/maven/browser/MvnGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, Istomin Andrei
+ * Copyright (c) 2019 Andrej Istomin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/aistomin/maven/browser/MvnPackagingType.java
+++ b/src/main/java/com/github/aistomin/maven/browser/MvnPackagingType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, Istomin Andrei
+ * Copyright (c) 2019 Andrej Istomin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/aistomin/maven/browser/MvnRepo.java
+++ b/src/main/java/com/github/aistomin/maven/browser/MvnRepo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, Istomin Andrei
+ * Copyright (c) 2019 Andrej Istomin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/aistomin/maven/browser/package-info.java
+++ b/src/main/java/com/github/aistomin/maven/browser/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, Istomin Andrei
+ * Copyright (c) 2019 Andrej Istomin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/github/aistomin/maven/browser/MavenArtifactTest.java
+++ b/src/test/java/com/github/aistomin/maven/browser/MavenArtifactTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, Istomin Andrei
+ * Copyright (c) 2019 Andrej Istomin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/github/aistomin/maven/browser/MavenArtifactVersionTest.java
+++ b/src/test/java/com/github/aistomin/maven/browser/MavenArtifactVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, Istomin Andrei
+ * Copyright (c) 2019 Andrej Istomin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/github/aistomin/maven/browser/MavenCentralTest.java
+++ b/src/test/java/com/github/aistomin/maven/browser/MavenCentralTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, Istomin Andrei
+ * Copyright (c) 2019 Andrej Istomin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/github/aistomin/maven/browser/MavenDependencyTest.java
+++ b/src/test/java/com/github/aistomin/maven/browser/MavenDependencyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, Istomin Andrei
+ * Copyright (c) 2019 Andrej Istomin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/github/aistomin/maven/browser/MavenGroupTest.java
+++ b/src/test/java/com/github/aistomin/maven/browser/MavenGroupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, Istomin Andrei
+ * Copyright (c) 2019 Andrej Istomin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/github/aistomin/maven/browser/package-info.java
+++ b/src/test/java/com/github/aistomin/maven/browser/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, Istomin Andrei
+ * Copyright (c) 2019 Andrej Istomin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
The notice read `Copyright (c) 2019-2022, Istomin Andrei` in 20 places: a stale
end year, the old spelling of the given name, and a surname-first order that is
a transcription artifact.

## The year

Fixed at **2019**, the year of first publication. Bumping it every January is
the problem, not the fix: the year carries no legal weight under the Berne
Convention, Apache's own boilerplate uses a single year, and the ASF does not
update years in headers. A scheduled bump was rejected — when the cron silently
stops firing we are back here, but believing it is handled. A constant notice is
one that can never start failing on its own.

## The license was not detectable

`LICENSE` held only the 13-line notice, which is the *header boilerplate* from
the Apache 2.0 appendix, not the license text. GitHub and every license scanner
reported this repository as `NOASSERTION` — no identifiable license at all,
which for a library published to Maven Central reads as "unknown license" in a
consumer's compliance scan.

`LICENSE` is now the verbatim 202-line text from apache.org, and the README
carries a badge that reads GitHub's detection rather than asserting the license
by hand. The badge shows `not identifiable by github` today and flips to
`Apache-2.0` once this merges.

## One copy, and the headers are derived from it

`LICENSE`'s last 13 lines are the "APPENDIX: How to apply the Apache License to
your work" boilerplate — Apache's own instruction for what each source file
should carry. `maven-antrun-plugin` extracts them on every build, de-indents
them, and fills the `Copyright [yyyy] [name of copyright owner]` placeholder
from `<inceptionYear>` and `<organization>`. `license-maven-plugin` then checks
every `.java` header against the result and fails the build on drift.

Exactly three values are authored anywhere — the Apache text in `LICENSE`, the
year, and the name. The notice itself is written nowhere, so there is nothing to
keep in sync.

Run `mvn validate license:format` to rewrite the headers; never edit one by hand.

## What was rejected, and why

A Checkstyle `RegexpHeader` module or a `conf/header.txt` template. Both work by
holding a **second copy** of the notice for the first to be checked against, and
nothing would check that copy against `LICENSE` — replace the license and the
build stays green while every header lies about it.

## Verification

- `mvn clean install` — green, 36 tests pass.
- Swap `LICENSE` to MIT → all 19 headers flagged, build fails.
- Hand-edit one header to `2019-2024` → that file flagged, build fails;
  `mvn validate license:format` restores it from `LICENSE`.
- All 19 `.java` files changed by exactly one line each — the copyright line —
  which is itself proof the extraction reproduces the existing header verbatim.
- `LICENSE` verified byte-identical to the upstream apache.org text.

Closes #538
