### PR TITLE
build(#537): raise the jacoco line coverage limit to 95%

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ Notes on the build:
   invalid HTML in a comment **fails the build** — Checkstyle checks that Javadoc exists,
   doclint checks that it is correct.
 - PMD, duplicate-finder, and `maven-dependencies-analyser` run at `verify`.
-- JaCoCo enforces **90% line coverage per package** (`jacoco:check`); new code needs tests.
+- JaCoCo enforces **95% line coverage per package** (`jacoco:check`); new code needs tests.
 - Tests are JUnit 5 (Jupiter). `MavenCentralTest` hits the real Maven Central network APIs,
   so the full build needs network access.
 
@@ -262,7 +262,7 @@ to push.
 
    It needs JDK 21 and network access (`MavenCentralTest` calls the real Maven Central
    APIs); mention in the proposal if either is missing. Remember the build gates: strict
-   Checkstyle at `validate`, PMD at `verify`, and JaCoCo's 90% line coverage per package —
+   Checkstyle at `validate`, PMD at `verify`, and JaCoCo's 95% line coverage per package —
    new code without tests fails the build.
 
    Once implemented: run the full build and report the real result.

--- a/pom.xml
+++ b/pom.xml
@@ -318,7 +318,7 @@
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.9</minimum>
+                                            <minimum>0.95</minimum>
                                         </limit>
                                     </limits>
                                 </rule>


### PR DESCRIPTION
Raises the `jacoco:check` per-package line coverage limit from 90% to 95%, and updates the
two places in `CLAUDE.md` that documented the old rule.

The 90% limit left so much headroom over the actual 96.41% that coverage could fall a long
way before the build noticed. 95% keeps the bar close to reality and matches the limit
[maven-dependencies-analyser](https://github.com/aistomin/maven-dependencies-analyser) sets
for itself.

No new tests: the current coverage already clears the new limit, so this is a tightening of
an existing gate rather than a behaviour change.

Verification — `mvn clean install` passes on JDK 21:

- 36 tests, 0 failures, 0 errors
- `jacoco:check`: "All coverage checks have been met."
- Actual coverage from `target/site/jacoco/jacoco.csv`: line **96.41%** (188 covered, 7
  missed of 195), branch **73.81%** (31 covered, 11 missed of 42)
- Enforcement confirmed rather than assumed: a throwaway bump to 0.97 made `jacoco:check`
  fail, so the limit genuinely bites at the new value

Two things worth keeping in mind, neither addressed here:

- The margin is thin. At 195 lines, 95% allows 9 missed lines and there are 7, so there are
  two lines of slack. As the ticket says, if that proves too tight the honest fix is more
  tests rather than lowering the limit again.
- Branch coverage (73.81%) is the real gap that the high line coverage hides. The limit
  stays LINE-based here; a `BRANCH` limit is a reasonable follow-up ticket.

Closes #537