### PR TITLE
fix(#516)!: throw MvnException when the version is not in the repo

### DIFF
--- a/src/main/java/com/github/aistomin/maven/browser/MavenCentral.java
+++ b/src/main/java/com/github/aistomin/maven/browser/MavenCentral.java
@@ -218,7 +218,9 @@ public final class MavenCentral implements MvnRepo {
             final List<String> allVersions = parseMetadataXml(
                 this.get(url, HttpResponse.BodyHandlers.ofInputStream())
             );
-            final int endIndex = Math.min(start + rows, allVersions.size());
+            final int endIndex = (int) Math.min(
+                (long) start + rows, allVersions.size()
+            );
             final List<String> pagedVersions =
                 start < allVersions.size()
                     ? allVersions.subList(start, endIndex)
@@ -311,7 +313,7 @@ public final class MavenCentral implements MvnRepo {
             .findFirst()
             .orElse(null);
         if (loaded == null) {
-            throw new IllegalStateException(
+            throw new MvnException(
                 String.format(
                     "%s %s was not found in Maven Central.",
                     current.artifact().name(),

--- a/src/main/java/com/github/aistomin/maven/browser/MvnException.java
+++ b/src/main/java/com/github/aistomin/maven/browser/MvnException.java
@@ -30,4 +30,13 @@ public final class MvnException extends Exception {
     public MvnException(final Throwable cause) {
         super(cause);
     }
+
+    /**
+     * Ctor.
+     *
+     * @param message The error message.
+     */
+    public MvnException(final String message) {
+        super(message);
+    }
 }

--- a/src/main/java/com/github/aistomin/maven/browser/MvnRepo.java
+++ b/src/main/java/com/github/aistomin/maven/browser/MvnRepo.java
@@ -63,6 +63,9 @@ public interface MvnRepo {
 
     /**
      * Search for the versions of the artifact.
+     * The range is clamped to the amount of the versions which the repository
+     * has, so {@code rows} may be {@link Integer#MAX_VALUE} to ask for
+     * everything starting from {@code start}.
      *
      * @param artifact The artifact.
      * @param start Indent of the search.
@@ -80,7 +83,8 @@ public interface MvnRepo {
      *
      * @param version The version.
      * @return The list of the newer versions.
-     * @throws MvnException If the problem occurred while reading from the repo.
+     * @throws MvnException If the problem occurred while reading from the repo,
+     *  or if the version is not found in the repository.
      */
     List<MvnArtifactVersion> findVersionsNewerThan(
         MvnArtifactVersion version
@@ -92,7 +96,8 @@ public interface MvnRepo {
      *
      * @param version The version.
      * @return The list of the older versions.
-     * @throws MvnException If the problem occurred while reading from the repo.
+     * @throws MvnException If the problem occurred while reading from the repo,
+     *  or if the version is not found in the repository.
      */
     List<MvnArtifactVersion> findVersionsOlderThan(
         MvnArtifactVersion version

--- a/src/test/java/com/github/aistomin/maven/browser/MavenCentralTest.java
+++ b/src/test/java/com/github/aistomin/maven/browser/MavenCentralTest.java
@@ -325,6 +325,26 @@ final class MavenCentralTest {
     }
 
     /**
+     * Check that asking for everything from a non-zero start works. The amount
+     * of the rows is not added to the start index in {@code int} arithmetic,
+     * so {@link Integer#MAX_VALUE} rows do not overflow into a negative end
+     * index.
+     *
+     * @throws Exception If something went wrong.
+     */
+    @Test
+    void testFindVersionsWithMaxRows() throws Exception {
+        final List<MvnArtifactVersion> versions = new MavenCentral()
+            .findVersions(this.mine, 1, Integer.MAX_VALUE);
+        Assertions.assertEquals(this.vers.size() - 1, versions.size());
+        Assertions.assertEquals(this.vers.get(1), versions.get(0).name());
+        Assertions.assertEquals(
+            this.vers.get(this.vers.size() - 1),
+            versions.get(versions.size() - 1).name()
+        );
+    }
+
+    /**
      * Check that we correctly find the versions which are newer than provided
      * one.
      *
@@ -334,7 +354,7 @@ final class MavenCentralTest {
     void testFindVersionsNewerThan() throws Exception {
         final MvnRepo mvn = new MavenCentral();
         Assertions.assertThrows(
-            IllegalStateException.class,
+            MvnException.class,
             () -> {
                 mvn.findVersionsNewerThan(
                     new MavenArtifactVersion(
@@ -370,9 +390,9 @@ final class MavenCentralTest {
     void testFindVersionsOlderThan() throws Exception {
         final MvnRepo mvn = new MavenCentral();
         Assertions.assertThrows(
-            IllegalStateException.class,
+            MvnException.class,
             () -> {
-                mvn.findVersionsNewerThan(
+                mvn.findVersionsOlderThan(
                     new MavenArtifactVersion(
                         this.mine,
                         "wrong-version",


### PR DESCRIPTION
Brings the failure paths in `MavenCentral` in line with the `MvnException` contract that
every `MvnRepo` method declares.

### Point 1 — the not-found case

`findVersionsNewerThan`/`findVersionsOlderThan` reported a missing version with an unchecked
`IllegalStateException`. Whether a version exists in the repository is repository data, which
is exactly what the checked `MvnException` is for, so it now throws that. The message is
unchanged. This needed a new `MvnException(String)` ctor, since the case has no underlying
cause to wrap.

`MvnRepo`'s `@throws` text on both methods was widened to say so — `MvnException` no longer
means only "a problem occurred while reading from the repo".

### Point 2 — no change needed

The ticket describes `parseJsonResponse` blindly casting `response` → `docs` with
json-simple. That was overtaken by #521, which replaced json-simple with Jackson: the method
now navigates with `path()`, so a missing field, an error payload or a schema change yields
an empty list rather than `ClassCastException`/`NullPointerException`, and malformed JSON
arrives as `JsonProcessingException` (an `IOException`) which is already wrapped into
`MvnException`.

### Point 3 — the overflow only

`start + rows` was computed in `int` arithmetic, so `findVersions(artifact, 1,
Integer.MAX_VALUE)` wrapped to a negative end index and died with
`IllegalArgumentException: fromIndex(1) > toIndex(-2147483648)`. That is the
"give me everything from here" idiom the class already uses on itself at
`MavenCentral.java:307`, so the sum is now widened to `long` before being clamped to the
list size, and the behaviour is documented on `MvnRepo.findVersions`.

Validating `null`/negative paging arguments was deliberately left out. Those are programmer
errors that already fail loudly today; guarding them would only improve the message text,
at the cost of extra branches and the tests to cover them.

### Tests

- The two tests asserting `IllegalStateException` now assert `MvnException` — this is the
  behaviour change the ticket warned about.
- New `testFindVersionsWithMaxRows` covers the overflow. It is a real test: with the
  production fix reverted it fails with the exact `IllegalArgumentException` above.
- Fixed a copy-paste bug in `testFindVersionsOlderThan`, which called `findVersionsNewerThan`
  — the "older than" not-found path had never been tested.

### Verification

`mvn clean install` passes on JDK 21: 37 tests (was 36), 0 failures, JaCoCo line coverage
**96.46%** against the 95% limit.

### Breaking change

Callers catching `IllegalStateException` from `findVersionsNewerThan`/`findVersionsOlderThan`
must catch `MvnException` instead. Code compiles unchanged either way, since both methods
already declared `throws MvnException`.

Closes #516