### PR TITLE
fix(#522): correct MvnPackagingType javadoc and drop dead test code

### DIFF
--- a/src/main/java/com/github/aistomin/maven/browser/MvnPackagingType.java
+++ b/src/main/java/com/github/aistomin/maven/browser/MvnPackagingType.java
@@ -16,7 +16,7 @@
 package com.github.aistomin.maven.browser;
 
 /**
- * The interface of classes which represent the Maven artifacts' group.
+ * The packaging types which a Maven artifact's version can have.
  *
  * @since 1.0
  */

--- a/src/test/java/com/github/aistomin/maven/browser/MavenCentralTest.java
+++ b/src/test/java/com/github/aistomin/maven/browser/MavenCentralTest.java
@@ -31,7 +31,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.xml.sax.SAXParseException;
@@ -52,11 +51,6 @@ final class MavenCentralTest {
      * Five.
      */
     private static final int FIVE = 5;
-
-    /**
-     * Ten.
-     */
-    private static final int TEN = 10;
 
     /**
      * My previously created artifact which we can use for tests.
@@ -124,12 +118,7 @@ final class MavenCentralTest {
         );
         final List<MvnArtifact> found = mvn.findArtifacts("aistomin");
         Assertions.assertEquals(MavenCentralTest.FIVE, found.size());
-        Assertions.assertNotNull(
-            found.stream()
-                .filter(artifact -> artifact.equals(this.mine))
-                .findFirst()
-                .get()
-        );
+        Assertions.assertTrue(found.contains(this.mine));
     }
 
     /**


### PR DESCRIPTION
Three small defects, none affecting behaviour:

- `MvnPackagingType`'s class javadoc was a verbatim copy of `MvnGroup`'s
  ("The interface of classes which represent the Maven artifacts' group.").
  It is an enum of packaging types, and this is published javadoc.
- `MavenCentralTest` carried an unused `@Disabled` import and an unused
  `TEN` constant.
- `MavenCentralTest.testFindArtifacts` ended with
  `assertNotNull(found.stream().filter(...).findFirst().get())`, which can
  only pass or throw `NoSuchElementException` — it never failed as an
  assertion. Replaced with `assertTrue(found.contains(this.mine))`, the
  same idiom `testFindArtifactsWithFieldQuery` already uses.

`mvn clean install` passes: Checkstyle, PMD, javadoc doclint,
duplicate-finder and JaCoCo's 95% per-package coverage check are all green,
and `MavenCentralTest` runs 20 tests with no failures.

Closes #522