### PR TITLE
fix(#518)!: render gradle dependencies with the implementation config

### DIFF
--- a/src/main/java/com/github/aistomin/maven/browser/MavenDependency.java
+++ b/src/main/java/com/github/aistomin/maven/browser/MavenDependency.java
@@ -84,7 +84,7 @@ public final class MavenDependency implements MvnDependency {
     public String forGradle() {
         final MvnArtifact artifact = this.ver.artifact();
         return String.format(
-            "compile '%s:%s:%s'",
+            "implementation '%s:%s:%s'",
             artifact.group().name(),
             artifact.name(),
             this.ver.name()

--- a/src/main/java/com/github/aistomin/maven/browser/MvnDependency.java
+++ b/src/main/java/com/github/aistomin/maven/browser/MvnDependency.java
@@ -52,7 +52,8 @@ public interface MvnDependency {
     String forGroovyGrape();
 
     /**
-     * Converts the dependency to Gradle/Grails dependency string.
+     * Converts the dependency to Gradle/Grails dependency string. The
+     * dependency is rendered with the {@code implementation} configuration.
      *
      * @return Gradle/Grails dependency string.
      */

--- a/src/test/java/com/github/aistomin/maven/browser/MavenDependencyTest.java
+++ b/src/test/java/com/github/aistomin/maven/browser/MavenDependencyTest.java
@@ -41,7 +41,7 @@ final class MavenDependencyTest {
     @Test
     void testForGradle() throws Exception {
         Assertions.assertEquals(
-            "compile 'com.github.aistomin:jenkins-sdk:0.2.1'",
+            "implementation 'com.github.aistomin:jenkins-sdk:0.2.1'",
             this.dependency().forGradle()
         );
     }


### PR DESCRIPTION
`MavenDependency.forGradle()` rendered a dependency as `compile 'group:artifact:version'`.
The `compile` configuration was deprecated in Gradle 4.10 and removed in Gradle 7 (2021),
so pasting the generated snippet into any current Gradle build fails with
`Could not find method compile()`.

It now renders `implementation 'group:artifact:version'`, and the interface javadoc —
which is the published contract — names the configuration explicitly.

A Kotlin-DSL variant (`forGradleKts()`) stays out of scope, as the ticket notes.

**BREAKING CHANGE:** `forGradle()` returns `implementation '...'` instead of `compile '...'`.

`mvn clean install` passes: Checkstyle, PMD, javadoc doclint, duplicate-finder and
JaCoCo's 95% per-package coverage check are all green, 37 tests with no failures.

Closes #518