### PR TITLE
test(#520): serve maven central fixtures from a local http server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,20 @@ browsing Maven Central. It is published to Maven Central as
 
 ## Commands
 
+**Every `mvn` command below needs `JAVA_HOME` pointed at JDK 21 first.** This machine's
+default JDK is 8, because most other projects on it still need 8, so a bare `mvn` dies
+with `Unrecognized option: --add-opens` / `Could not create the Java Virtual Machine`
+before it does anything. That is an environment problem, never a problem with the change
+being built. The JDKs are managed by sdkman:
+
+```bash
+# Prefix every Maven invocation (do not rely on `current` — it points at 8)
+JAVA_HOME=~/.sdkman/candidates/java/21.0.5-tem mvn clean install
+
+# If that exact build is gone, see which 21 is installed
+ls ~/.sdkman/candidates/java/
+```
+
 ```bash
 # Full build — run this before submitting any PR (per README contribution guidelines)
 mvn clean install
@@ -99,8 +113,13 @@ Notes on the build:
   doclint checks that it is correct.
 - PMD, duplicate-finder, and `maven-dependencies-analyser` run at `verify`.
 - JaCoCo enforces **95% line coverage per package** (`jacoco:check`); new code needs tests.
-- Tests are JUnit 5 (Jupiter). `MavenCentralTest` hits the real Maven Central network APIs,
-  so the full build needs network access.
+- Tests are JUnit 5 (Jupiter). Almost all of `MavenCentralTest` reads from
+  `FakeMavenCentral`, a localhost HTTP server which serves the fixtures in
+  `src/test/resources/fixtures`, so the assertions do not depend on what Maven Central
+  happens to contain today. Two tests — the ones whose names end with `InMavenCentral` —
+  deliberately call the real APIs, so the full build still needs network access. They
+  assert loosely (non-empty, `contains`, `<=`) and must never assert an exact count of
+  live data.
 
 ## Architecture
 
@@ -260,10 +279,11 @@ to push.
    mvn clean install
    ```
 
-   It needs JDK 21 and network access (`MavenCentralTest` calls the real Maven Central
-   APIs); mention in the proposal if either is missing. Remember the build gates: strict
-   Checkstyle at `validate`, PMD at `verify`, and JaCoCo's 95% line coverage per package —
-   new code without tests fails the build.
+   It needs the JDK 21 `JAVA_HOME` prefix from the Commands section above (the machine
+   defaults to JDK 8) and network access (`MavenCentralTest`'s two `*InMavenCentral`
+   tests call the real Maven Central APIs); mention in the proposal if either is missing.
+   Remember the build gates: strict Checkstyle at `validate`, PMD at `verify`, and
+   JaCoCo's 95% line coverage per package — new code without tests fails the build.
 
    Once implemented: run the full build and report the real result.
 

--- a/src/test/java/com/github/aistomin/maven/browser/FakeMavenCentral.java
+++ b/src/test/java/com/github/aistomin/maven/browser/FakeMavenCentral.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2019 Andrej Istomin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.aistomin.maven.browser;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * A Maven Central which runs on localhost and answers out of the fixtures
+ * instead of out of the real repository.
+ * Only the paths which were explicitly registered are answered; everything
+ * else gets a 404, the same way the real repository reacts to an artifact
+ * which it does not have. That is what makes the tests prove that
+ * {@link MavenCentral} builds its URLs correctly: an answer only arrives if
+ * the URL is the one we expect.
+ *
+ * @since 5.2
+ */
+final class FakeMavenCentral implements AutoCloseable {
+
+    /**
+     * The path under which the fake serves the repository, mirroring the
+     * layout of the real repo1.maven.org.
+     */
+    private static final String REPO = "/maven2";
+
+    /**
+     * The path under which the fake serves the search API, mirroring the
+     * layout of the real search.maven.org.
+     */
+    private static final String SEARCH = "/solrsearch/select";
+
+    /**
+     * The answers which the fake gives, by the path they are registered for.
+     */
+    private final Map<String, Answer> answers;
+
+    /**
+     * The query string of the request which arrived last, or null if the fake
+     * was not asked anything yet.
+     */
+    private final AtomicReference<String> last;
+
+    /**
+     * The server which does the talking.
+     */
+    private final HttpServer server;
+
+    /**
+     * Ctor. Starts the server on a free port of the loopback interface.
+     *
+     * @throws IOException If the server can not be started.
+     */
+    FakeMavenCentral() throws IOException {
+        this.answers = new ConcurrentHashMap<>();
+        this.last = new AtomicReference<>();
+        this.server = HttpServer.create(
+            new InetSocketAddress("127.0.0.1", 0), 0
+        );
+        this.server.createContext("/", this::answer);
+        this.server.start();
+    }
+
+    /**
+     * Read a fixture out of the test classpath.
+     *
+     * @param name The name of the fixture file.
+     * @return The content of the fixture.
+     * @throws IOException If the fixture can not be read.
+     */
+    static String fixture(final String name) throws IOException {
+        final String path = String.format("/fixtures/%s", name);
+        try (InputStream stream =
+            FakeMavenCentral.class.getResourceAsStream(path)) {
+            if (stream == null) {
+                throw new IOException(
+                    String.format("The fixture %s does not exist.", path)
+                );
+            }
+            return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    /**
+     * Answer the metadata of the given artifact with the given body.
+     *
+     * @param artifact The artifact whose metadata is asked for.
+     * @param body The body of the answer.
+     * @return This fake, so that the calls can be chained.
+     */
+    FakeMavenCentral withMetadata(
+        final MvnArtifact artifact, final String body
+    ) {
+        return this.withAnswer(
+            FakeMavenCentral.metadataPath(artifact),
+            HttpURLConnection.HTTP_OK,
+            body
+        );
+    }
+
+    /**
+     * Answer the search requests with the given body.
+     *
+     * @param body The body of the answer.
+     * @return This fake, so that the calls can be chained.
+     */
+    FakeMavenCentral withSearch(final String body) {
+        return this.withAnswer(
+            FakeMavenCentral.SEARCH, HttpURLConnection.HTTP_OK, body
+        );
+    }
+
+    /**
+     * Answer the search requests with the given HTTP status.
+     *
+     * @param status The status of the answer.
+     * @return This fake, so that the calls can be chained.
+     */
+    FakeMavenCentral withSearchStatus(final int status) {
+        return this.withAnswer(FakeMavenCentral.SEARCH, status, "");
+    }
+
+    /**
+     * Create the browser which reads from this fake.
+     *
+     * @return The browser.
+     */
+    MvnRepo browser() {
+        final String url = String.format(
+            "http://127.0.0.1:%d", this.server.getAddress().getPort()
+        );
+        return new MavenCentral(
+            String.format("%s%s", url, FakeMavenCentral.REPO),
+            String.format("%s%s", url, FakeMavenCentral.SEARCH)
+        );
+    }
+
+    /**
+     * The query string of the request which arrived last. The tests which are
+     * about how a request is built assert on it, because the body of the
+     * answer can not tell them whether the search string reached the fake in
+     * one piece.
+     *
+     * @return The query string, or null if nothing was asked yet.
+     */
+    String lastQuery() {
+        return this.last.get();
+    }
+
+    @Override
+    public void close() {
+        this.server.stop(0);
+    }
+
+    /**
+     * The path under which the metadata of the given artifact is served.
+     *
+     * @param artifact The artifact.
+     * @return The path.
+     */
+    private static String metadataPath(final MvnArtifact artifact) {
+        return String.format(
+            "%s/%s/%s/maven-metadata.xml",
+            FakeMavenCentral.REPO,
+            artifact.group().name().replace('.', '/'),
+            artifact.name()
+        );
+    }
+
+    /**
+     * Register an answer for the given path.
+     *
+     * @param path The path which is answered.
+     * @param status The status of the answer.
+     * @param body The body of the answer.
+     * @return This fake, so that the calls can be chained.
+     */
+    private FakeMavenCentral withAnswer(
+        final String path, final int status, final String body
+    ) {
+        this.answers.put(path, new Answer(status, body));
+        return this;
+    }
+
+    /**
+     * Answer one request: remember its query and write back whatever is
+     * registered for its path, or a 404 if nothing is.
+     *
+     * @param exchange The request which arrived.
+     * @throws IOException If the answer can not be written.
+     */
+    private void answer(final HttpExchange exchange) throws IOException {
+        this.last.set(exchange.getRequestURI().getRawQuery());
+        final Answer registered = this.answers.get(
+            exchange.getRequestURI().getPath()
+        );
+        final Answer given;
+        if (registered == null) {
+            given = new Answer(HttpURLConnection.HTTP_NOT_FOUND, "");
+        } else {
+            given = registered;
+        }
+        final byte[] bytes = given.body().getBytes(StandardCharsets.UTF_8);
+        final long length;
+        if (bytes.length == 0) {
+            length = -1L;
+        } else {
+            length = bytes.length;
+        }
+        exchange.sendResponseHeaders(given.status(), length);
+        try (OutputStream out = exchange.getResponseBody()) {
+            out.write(bytes);
+        }
+    }
+
+    /**
+     * One answer of the fake.
+     *
+     * @param status The HTTP status of the answer.
+     * @param body The body of the answer.
+     * @since 5.2
+     */
+    private record Answer(int status, String body) {
+    }
+}

--- a/src/test/java/com/github/aistomin/maven/browser/MavenCentralTest.java
+++ b/src/test/java/com/github/aistomin/maven/browser/MavenCentralTest.java
@@ -16,20 +16,14 @@
 package com.github.aistomin.maven.browser;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
-import java.io.OutputStream;
-import java.net.HttpURLConnection;
-import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.http.HttpTimeoutException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.IntStream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -37,10 +31,26 @@ import org.xml.sax.SAXParseException;
 
 /**
  * The tests for {@link MavenCentral}.
+ * Almost all of them read from {@link FakeMavenCentral}, which serves the
+ * fixtures in "src/test/resources/fixtures" instead of the real repository.
+ * Maven Central is a live, mutable place: asserting on what it contains today
+ * means the suite breaks the moment somebody publishes something, and it also
+ * hides the answers which the real repository never gives - a 500, a broken
+ * JSON, a metadata file without a single version. The two tests whose names
+ * end with "InMavenCentral" are the exception: they do talk to the real
+ * repository, because a suite which only ever talks to our own fake can not
+ * notice that we stopped being able to talk to the real one. Their assertions
+ * are deliberately loose - "not empty", "contains" - so that they check that
+ * we can read Maven Central, not what Maven Central happens to hold.
  *
  * @since 0.1
  */
 final class MavenCentralTest {
+
+    /**
+     * Two.
+     */
+    private static final int TWO = 2;
 
     /**
      * Three.
@@ -51,6 +61,18 @@ final class MavenCentralTest {
      * Five.
      */
     private static final int FIVE = 5;
+
+    /**
+     * The name of the fixture with the metadata of my artifact.
+     */
+    private static final String MINE_METADATA =
+        "jenkins-sdk-maven-metadata.xml";
+
+    /**
+     * The name of the fixture with the metadata of Guava.
+     */
+    private static final String GUAVA_METADATA =
+        "guava-maven-metadata.xml";
 
     /**
      * My previously created artifact which we can use for tests.
@@ -69,7 +91,7 @@ final class MavenCentralTest {
     );
 
     /**
-     * The list of the versions of my artifact which we use for this test.
+     * The versions of my artifact, newest first, as the fixture holds them.
      */
     private final List<String> vers = Arrays.asList(
         "0.2.1",
@@ -80,127 +102,83 @@ final class MavenCentralTest {
     );
 
     /**
-     * Check that we correctly find the artifacts with start and rows
-     * parameters.
+     * Check that we can still search the real Maven Central. Nothing is
+     * asserted about which artifacts come back, only that some do and that
+     * they are whole, because the answer changes whenever somebody publishes
+     * something named like the search string.
      *
      * @throws Exception If something went wrong.
      */
     @Test
-    void testFindArtifacts() throws Exception {
+    void testFindArtifactsInMavenCentral() throws Exception {
         final MvnRepo mvn = new MavenCentral();
-        final String search = "guice";
-        final List<MvnArtifact> artifacts = mvn.findArtifacts(
-            search, 0, MavenCentral.MAX_ROWS
+        final List<MvnArtifact> artifacts = mvn.findArtifacts("guice");
+        Assertions.assertFalse(artifacts.isEmpty());
+        Assertions.assertTrue(artifacts.size() <= MavenCentral.MAX_ROWS);
+        artifacts.forEach(
+            artifact -> {
+                Assertions.assertFalse(artifact.name().isBlank());
+                Assertions.assertFalse(artifact.group().name().isBlank());
+            }
         );
-        Assertions.assertEquals(
-            MavenCentral.MAX_ROWS, artifacts.size()
-        );
-        final List<MvnArtifact> def = mvn.findArtifacts(search);
-        Assertions.assertEquals(
-            artifacts.size(), def.size()
-        );
-        def.forEach(
-            artifact ->
-                Assertions.assertEquals(
-                    def.indexOf(artifact), artifacts.indexOf(artifact)
-                )
-        );
-        final int start = 2;
-        final List<MvnArtifact> part = mvn.findArtifacts(
-            search, start, MavenCentralTest.FIVE
-        );
-        Assertions.assertEquals(MavenCentralTest.FIVE, part.size());
-        part.forEach(
-            artifact ->
-                Assertions.assertEquals(
-                    part.indexOf(artifact), artifacts.indexOf(artifact) - start
-                )
-        );
-        final List<MvnArtifact> found = mvn.findArtifacts("aistomin");
-        Assertions.assertEquals(MavenCentralTest.FIVE, found.size());
-        Assertions.assertTrue(found.contains(this.mine));
-    }
-
-    /**
-     * Check that we can search using a string which contains a space.
-     *
-     * @throws Exception If something went wrong.
-     */
-    @Test
-    void testFindArtifactsWithSpace() throws Exception {
-        Assertions.assertFalse(
-            new MavenCentral().findArtifacts("guice inject").isEmpty()
-        );
-    }
-
-    /**
-     * Check that we can search using the Maven search API field syntax, which
-     * contains characters that are not allowed in a URL.
-     *
-     * @throws Exception If something went wrong.
-     */
-    @Test
-    void testFindArtifactsWithFieldQuery() throws Exception {
-        final String group = this.mine.group().name();
-        final List<MvnArtifact> found = new MavenCentral().findArtifacts(
-            String.format("g:\"%s\"", group)
-        );
-        Assertions.assertFalse(found.isEmpty());
-        Assertions.assertTrue(found.contains(this.mine));
-        found.forEach(
-            artifact ->
-                Assertions.assertEquals(group, artifact.group().name())
-        );
-    }
-
-    /**
-     * Check that the request parameters can not be injected via the search
-     * string.
-     *
-     * @throws Exception If something went wrong.
-     */
-    @Test
-    void testFindArtifactsIgnoresInjectedParameters() throws Exception {
         Assertions.assertTrue(
-            new MavenCentral()
-                .findArtifacts("a&rows=1000", 0, MavenCentralTest.FIVE)
-                .size() <= MavenCentralTest.FIVE
+            mvn.findArtifacts("guice", 0, MavenCentralTest.FIVE).size()
+                <= MavenCentralTest.FIVE
         );
+    }
+
+    /**
+     * Check that we can still read the versions out of the real Maven
+     * Central. My artifact was last released in 2016, but the assertions
+     * still allow it to grow: what is checked is that the versions we know
+     * are there are among the ones we get, not that they are the only ones.
+     *
+     * @throws Exception If something went wrong.
+     */
+    @Test
+    void testFindVersionsInMavenCentral() throws Exception {
+        final List<MvnArtifactVersion> versions =
+            new MavenCentral().findVersions(this.mine);
+        Assertions.assertTrue(versions.size() >= this.vers.size());
+        Assertions.assertTrue(
+            MavenCentralTest.names(versions).contains("0.2.1")
+        );
+        for (final MvnArtifactVersion ver : versions) {
+            Assertions.assertEquals(this.mine.name(), ver.artifact().name());
+            Assertions.assertEquals(
+                this.mine.group().name(), ver.artifact().group().name()
+            );
+        }
     }
 
     /**
      * Check that the artifacts are read out of a search answer which has the
      * shape the real search API produces: the documents sit in "docs" inside
-     * "response", and each of them carries its group in "g" and its name
-     * in "a".
+     * "response", and each of them carries its own group in "g" and its own
+     * name in "a". The fixture holds two documents from two different groups,
+     * so a reader which picks the group up once for the whole answer instead
+     * of once per document can not pass.
      *
      * @throws Exception If something went wrong.
      */
     @Test
     void testFindArtifactsParsesSearchAnswer() throws Exception {
-        final HttpServer server = MavenCentralTest.serving(
-            String.join(
-                "",
-                "{\"responseHeader\":{\"status\":0,\"QTime\":1},",
-                "\"response\":{\"numFound\":2,\"start\":0,\"docs\":[",
-                "{\"id\":\"com.github.aistomin:jenkins-sdk\",",
-                "\"g\":\"com.github.aistomin\",\"a\":\"jenkins-sdk\",",
-                "\"latestVersion\":\"0.2.1\",\"p\":\"maven-plugin\",",
-                "\"timestamp\":1479480474000,\"versionCount\":5},",
-                "{\"id\":\"com.google.guava:guava\",",
-                "\"g\":\"com.google.guava\",\"a\":\"guava\",",
-                "\"latestVersion\":\"33.0.0\",\"p\":\"bundle\",",
-                "\"timestamp\":1700000000000,\"versionCount\":99}",
-                "]},\"spellcheck\":{\"suggestions\":[]}}"
-            )
-        );
-        try {
-            Assertions.assertEquals(
-                Arrays.asList(this.mine, this.guava),
-                MavenCentralTest.talkingTo(server).findArtifacts("whatever")
+        try (FakeMavenCentral fake = new FakeMavenCentral()) {
+            fake.withSearch(
+                FakeMavenCentral.fixture("search-mixed-groups.json")
             );
-        } finally {
-            server.stop(0);
+            Assertions.assertEquals(
+                Arrays.asList(
+                    new MavenArtifact(
+                        new MavenGroup("org.openidentityplatform.commons"),
+                        "guice"
+                    ),
+                    new MavenArtifact(
+                        new MavenGroup("io.github.replay-framework"), "guice"
+                    )
+                ),
+                fake.browser().findArtifacts("guice")
+            );
         }
     }
 
@@ -214,17 +192,11 @@ final class MavenCentralTest {
      */
     @Test
     void testFindArtifactsParsesAnswerWithoutDocuments() throws Exception {
-        final HttpServer server = MavenCentralTest.serving(
-            "{\"responseHeader\":{\"status\":0}}"
-        );
-        try {
+        try (FakeMavenCentral fake = new FakeMavenCentral()) {
+            fake.withSearch("{\"responseHeader\":{\"status\":0}}");
             Assertions.assertTrue(
-                MavenCentralTest.talkingTo(server)
-                    .findArtifacts("whatever")
-                    .isEmpty()
+                fake.browser().findArtifacts("whatever").isEmpty()
             );
-        } finally {
-            server.stop(0);
         }
     }
 
@@ -236,9 +208,9 @@ final class MavenCentralTest {
      */
     @Test
     void testFindArtifactsRejectsBrokenJson() throws Exception {
-        final HttpServer server = MavenCentralTest.serving("{\"response\":");
-        try {
-            final MvnRepo mvn = MavenCentralTest.talkingTo(server);
+        try (FakeMavenCentral fake = new FakeMavenCentral()) {
+            fake.withSearch("{\"response\":");
+            final MvnRepo mvn = fake.browser();
             Assertions.assertInstanceOf(
                 JsonProcessingException.class,
                 Assertions.assertThrows(
@@ -246,26 +218,443 @@ final class MavenCentralTest {
                     () -> mvn.findArtifacts("whatever")
                 ).getCause()
             );
-        } finally {
-            server.stop(0);
         }
     }
 
     /**
-     * Check that an artifact whose coordinates contain a character which is not
-     * allowed in a URL fails with {@link MvnException} rather than with an
-     * unchecked exception.
+     * Check that the search without paging asks for the first page of
+     * {@link MavenCentral#MAX_ROWS} rows.
+     *
+     * @throws Exception If something went wrong.
      */
     @Test
-    void testFindVersionsWithSpaceInCoordinates() {
-        Assertions.assertThrows(
-            MvnException.class,
-            () -> new MavenCentral().findVersions(
-                new MavenArtifact(
-                    new MavenGroup("com.github aistomin"), "jenkins sdk"
+    void testFindArtifactsAsksForTheFirstPage() throws Exception {
+        try (FakeMavenCentral fake = new FakeMavenCentral()) {
+            fake.withSearch(
+                FakeMavenCentral.fixture("search-single-group.json")
+            );
+            fake.browser().findArtifacts("guice");
+            Assertions.assertEquals(
+                String.format(
+                    "q=guice&start=0&rows=%d&wt=json", MavenCentral.MAX_ROWS
+                ),
+                fake.lastQuery()
+            );
+        }
+    }
+
+    /**
+     * Check that a search string which contains a space reaches the
+     * repository in one piece. The answer can not show this - our own fake
+     * would answer whatever is asked - so the request itself is asserted.
+     *
+     * @throws Exception If something went wrong.
+     */
+    @Test
+    void testFindArtifactsEncodesSpace() throws Exception {
+        try (FakeMavenCentral fake = new FakeMavenCentral()) {
+            fake.withSearch(
+                FakeMavenCentral.fixture("search-single-group.json")
+            );
+            Assertions.assertFalse(
+                fake.browser().findArtifacts("guice inject").isEmpty()
+            );
+            Assertions.assertEquals(
+                String.format(
+                    "q=guice+inject&start=0&rows=%d&wt=json",
+                    MavenCentral.MAX_ROWS
+                ),
+                fake.lastQuery()
+            );
+        }
+    }
+
+    /**
+     * Check that the Maven search API field syntax survives the trip: the
+     * quotes and the colon of {@code g:"..."} are not allowed in a URL, so
+     * they have to arrive encoded rather than mangled or dropped.
+     *
+     * @throws Exception If something went wrong.
+     */
+    @Test
+    void testFindArtifactsEncodesFieldQuery() throws Exception {
+        final String group = this.mine.group().name();
+        try (FakeMavenCentral fake = new FakeMavenCentral()) {
+            fake.withSearch(
+                FakeMavenCentral.fixture("search-single-group.json")
+            );
+            final List<MvnArtifact> found = fake.browser().findArtifacts(
+                String.format("g:\"%s\"", group)
+            );
+            Assertions.assertEquals(
+                String.format(
+                    "q=g%%3A%%22%s%%22&start=0&rows=%d&wt=json",
+                    group, MavenCentral.MAX_ROWS
+                ),
+                fake.lastQuery()
+            );
+            Assertions.assertEquals(MavenCentralTest.THREE, found.size());
+            Assertions.assertTrue(found.contains(this.mine));
+            found.forEach(
+                artifact ->
+                    Assertions.assertEquals(group, artifact.group().name())
+            );
+        }
+    }
+
+    /**
+     * Check that the request parameters can not be injected via the search
+     * string. A search string which carries its own "rows" has to end up
+     * encoded inside "q", so that the "rows" the caller asked for stays the
+     * only one in the request.
+     *
+     * @throws Exception If something went wrong.
+     */
+    @Test
+    void testFindArtifactsIgnoresInjectedParameters() throws Exception {
+        try (FakeMavenCentral fake = new FakeMavenCentral()) {
+            fake.withSearch(
+                FakeMavenCentral.fixture("search-single-group.json")
+            );
+            fake.browser().findArtifacts(
+                "a&rows=1000", 0, MavenCentralTest.FIVE
+            );
+            Assertions.assertEquals(
+                String.format(
+                    "q=a%%26rows%%3D1000&start=0&rows=%d&wt=json",
+                    MavenCentralTest.FIVE
+                ),
+                fake.lastQuery()
+            );
+        }
+    }
+
+    /**
+     * Check that a repository which answers the search with an error status
+     * fails with {@link MvnException} instead of the error page being parsed
+     * as if it were an answer.
+     *
+     * @throws Exception If something went wrong.
+     */
+    @Test
+    void testFindArtifactsRejectsErrorStatus() throws Exception {
+        try (FakeMavenCentral fake = new FakeMavenCentral()) {
+            fake.withSearchStatus(500);
+            final MvnRepo mvn = fake.browser();
+            Assertions.assertInstanceOf(
+                IOException.class,
+                Assertions.assertThrows(
+                    MvnException.class,
+                    () -> mvn.findArtifacts("whatever")
+                ).getCause()
+            );
+        }
+    }
+
+    /**
+     * Check that we correctly find the versions of the artifact, and that
+     * asking for a page of them gives that page.
+     *
+     * @throws Exception If something went wrong.
+     */
+    @Test
+    void testFindVersions() throws Exception {
+        try (FakeMavenCentral fake = this.serving()) {
+            final MvnRepo mvn = fake.browser();
+            final List<MvnArtifactVersion> versions =
+                mvn.findVersions(this.mine);
+            Assertions.assertEquals(
+                this.vers, MavenCentralTest.names(versions)
+            );
+            for (final MvnArtifactVersion ver : versions) {
+                Assertions.assertEquals(
+                    this.mine.name(), ver.artifact().name()
+                );
+                Assertions.assertEquals(
+                    this.mine.group().name(), ver.artifact().group().name()
+                );
+            }
+            Assertions.assertEquals(
+                this.vers.subList(1, MavenCentralTest.THREE),
+                MavenCentralTest.names(
+                    mvn.findVersions(this.mine, 1, MavenCentralTest.TWO)
                 )
-            )
-        );
+            );
+        }
+    }
+
+    /**
+     * Check that asking for everything from a non-zero start works. The amount
+     * of the rows is not added to the start index in {@code int} arithmetic,
+     * so {@link Integer#MAX_VALUE} rows do not overflow into a negative end
+     * index.
+     *
+     * @throws Exception If something went wrong.
+     */
+    @Test
+    void testFindVersionsWithMaxRows() throws Exception {
+        try (FakeMavenCentral fake = this.serving()) {
+            Assertions.assertEquals(
+                this.vers.subList(1, this.vers.size()),
+                MavenCentralTest.names(
+                    fake.browser().findVersions(
+                        this.mine, 1, Integer.MAX_VALUE
+                    )
+                )
+            );
+        }
+    }
+
+    /**
+     * Check that asking for a page which starts past the last version gives
+     * an empty list instead of failing on the index.
+     *
+     * @throws Exception If something went wrong.
+     */
+    @Test
+    void testFindVersionsPastTheLastPage() throws Exception {
+        try (FakeMavenCentral fake = this.serving()) {
+            Assertions.assertTrue(
+                fake.browser()
+                    .findVersions(this.mine, 99, MavenCentral.MAX_ROWS)
+                    .isEmpty()
+            );
+        }
+    }
+
+    /**
+     * Check that we correctly find the versions which are newer than provided
+     * one.
+     *
+     * @throws Exception If something went wrong.
+     */
+    @Test
+    void testFindVersionsNewerThan() throws Exception {
+        try (FakeMavenCentral fake = this.serving()) {
+            final MvnRepo mvn = fake.browser();
+            Assertions.assertThrows(
+                MvnException.class,
+                () -> mvn.findVersionsNewerThan(this.version("not-existing"))
+            );
+            final String from =
+                this.vers.get(this.vers.size() - MavenCentralTest.TWO);
+            Assertions.assertEquals(
+                this.vers.subList(0, MavenCentralTest.THREE),
+                MavenCentralTest.names(
+                    mvn.findVersionsNewerThan(this.version(from))
+                )
+            );
+        }
+    }
+
+    /**
+     * Check that we correctly find the versions which are older than provided
+     * one.
+     *
+     * @throws Exception If something went wrong.
+     */
+    @Test
+    void testFindVersionsOlderThan() throws Exception {
+        try (FakeMavenCentral fake = this.serving()) {
+            final MvnRepo mvn = fake.browser();
+            Assertions.assertThrows(
+                MvnException.class,
+                () -> mvn.findVersionsOlderThan(this.version("wrong-version"))
+            );
+            Assertions.assertEquals(
+                this.vers.subList(MavenCentralTest.THREE, this.vers.size()),
+                MavenCentralTest.names(
+                    mvn.findVersionsOlderThan(
+                        this.version(this.vers.get(MavenCentralTest.TWO))
+                    )
+                )
+            );
+        }
+    }
+
+    /**
+     * Check that a version which does not start with a digit does not break
+     * the search of the newer versions: everything Guava released after r09
+     * comes back, and neither r09 itself nor the older r03 does.
+     *
+     * @throws Exception If something went wrong.
+     */
+    @Test
+    void testFindVersionsNewerThanNonNumericVersion() throws Exception {
+        try (FakeMavenCentral fake = this.serving()) {
+            Assertions.assertEquals(
+                Arrays.asList("33.7.1-jre", "10.0.1", "10.0", "10.0-rc1"),
+                MavenCentralTest.names(
+                    fake.browser().findVersionsNewerThan(
+                        this.guavaVersion("r09")
+                    )
+                )
+            );
+        }
+    }
+
+    /**
+     * Check that the versions are ordered using Maven's rules: a release
+     * candidate is older than the release, and a non-numeric version is older
+     * than a numeric one.
+     *
+     * @throws Exception If something went wrong.
+     */
+    @Test
+    void testFindVersionsOlderThanQualifiedVersion() throws Exception {
+        try (FakeMavenCentral fake = this.serving()) {
+            Assertions.assertEquals(
+                Arrays.asList("10.0-rc1", "r09", "r03"),
+                MavenCentralTest.names(
+                    fake.browser().findVersionsOlderThan(
+                        this.guavaVersion("10.0")
+                    )
+                )
+            );
+        }
+    }
+
+    /**
+     * Check that a metadata file which has no versions in it gives an empty
+     * list, and that looking for something newer than a version of such an
+     * artifact says that the version is not there rather than saying that
+     * nothing is newer.
+     *
+     * @throws Exception If something went wrong.
+     */
+    @Test
+    void testFindVersionsParsesEmptyMetadata() throws Exception {
+        try (FakeMavenCentral fake = new FakeMavenCentral()) {
+            fake.withMetadata(
+                this.mine,
+                String.join(
+                    "",
+                    "<?xml version=\"1.0\"?>",
+                    "<metadata><versioning><versions/></versioning></metadata>"
+                )
+            );
+            final MvnRepo mvn = fake.browser();
+            Assertions.assertTrue(mvn.findVersions(this.mine).isEmpty());
+            Assertions.assertThrows(
+                MvnException.class,
+                () -> mvn.findVersionsNewerThan(this.version("0.2.1"))
+            );
+        }
+    }
+
+    /**
+     * Check that a metadata file which is not a well formed XML fails with
+     * {@link MvnException} rather than with an unchecked exception.
+     *
+     * @throws Exception If something went wrong.
+     */
+    @Test
+    void testFindVersionsRejectsMalformedXml() throws Exception {
+        try (FakeMavenCentral fake = new FakeMavenCentral()) {
+            fake.withMetadata(
+                this.mine, "<metadata><versioning><versions>"
+            );
+            final MvnRepo mvn = fake.browser();
+            Assertions.assertInstanceOf(
+                SAXParseException.class,
+                Assertions.assertThrows(
+                    MvnException.class,
+                    () -> mvn.findVersions(this.mine)
+                ).getCause()
+            );
+        }
+    }
+
+    /**
+     * Check that a metadata file which declares a DTD is rejected instead of
+     * being parsed. Such a file is the vehicle for XXE: the entity below
+     * points at a local file, and an unhardened parser would happily read it
+     * and hand its content back as a version name.
+     *
+     * @param dir The temporary directory with the "secret" file.
+     * @throws Exception If something went wrong.
+     */
+    @Test
+    void testFindVersionsRejectsMaliciousDoctype(
+        @TempDir final Path dir
+    ) throws Exception {
+        final Path secret = dir.resolve("secret.txt");
+        Files.writeString(secret, "top-secret");
+        try (FakeMavenCentral fake = new FakeMavenCentral()) {
+            fake.withMetadata(
+                this.mine,
+                String.join(
+                    "",
+                    "<?xml version=\"1.0\"?>",
+                    "<!DOCTYPE metadata [",
+                    String.format(
+                        "<!ENTITY xxe SYSTEM \"%s\">", secret.toUri()
+                    ),
+                    "]>",
+                    "<metadata><versioning><versions>",
+                    "<version>&xxe;</version>",
+                    "</versions></versioning></metadata>"
+                )
+            );
+            final MvnRepo mvn = fake.browser();
+            final Throwable cause = Assertions.assertThrows(
+                MvnException.class,
+                () -> mvn.findVersions(this.mine)
+            ).getCause();
+            Assertions.assertInstanceOf(SAXParseException.class, cause);
+            Assertions.assertTrue(
+                cause.getMessage().contains("DOCTYPE"), cause.getMessage()
+            );
+        }
+    }
+
+    /**
+     * Check that the metadata is looked up under the path which the artifact's
+     * coordinates spell out. The fake only answers the path of my artifact, so
+     * asking it for Guava has to end up on a path it does not know, and a
+     * repository which does not have an artifact answers 404, not silence.
+     *
+     * @throws Exception If something went wrong.
+     */
+    @Test
+    void testFindVersionsRejectsUnknownArtifact() throws Exception {
+        try (FakeMavenCentral fake = new FakeMavenCentral()) {
+            fake.withMetadata(
+                this.mine,
+                FakeMavenCentral.fixture(MavenCentralTest.MINE_METADATA)
+            );
+            final MvnRepo mvn = fake.browser();
+            Assertions.assertFalse(mvn.findVersions(this.mine).isEmpty());
+            Assertions.assertInstanceOf(
+                IOException.class,
+                Assertions.assertThrows(
+                    MvnException.class,
+                    () -> mvn.findVersions(this.guava)
+                ).getCause()
+            );
+        }
+    }
+
+    /**
+     * Check that an artifact whose coordinates contain a character which is
+     * not allowed in a URL fails with {@link MvnException} rather than with an
+     * unchecked exception.
+     *
+     * @throws Exception If something went wrong.
+     */
+    @Test
+    void testFindVersionsWithSpaceInCoordinates() throws Exception {
+        try (FakeMavenCentral fake = this.serving()) {
+            final MvnRepo mvn = fake.browser();
+            Assertions.assertThrows(
+                MvnException.class,
+                () -> mvn.findVersions(
+                    new MavenArtifact(
+                        new MavenGroup("com.github aistomin"), "jenkins sdk"
+                    )
+                )
+            );
+        }
     }
 
     /**
@@ -283,163 +672,6 @@ final class MavenCentralTest {
             MvnException.class,
             () -> repo.findVersions(this.mine)
         );
-    }
-
-    /**
-     * Check that we correctly find the versions of the artifact.
-     *
-     * @throws Exception If something went wrong.
-     */
-    @Test
-    void testFindVersions() throws Exception {
-        final List<MvnArtifactVersion> versions =
-            new MavenCentral().findVersions(this.mine);
-        Assertions.assertEquals(MavenCentralTest.FIVE, versions.size());
-        for (final MvnArtifactVersion ver : versions) {
-            Assertions.assertEquals(this.mine.name(), ver.artifact().name());
-            Assertions.assertEquals(
-                this.mine.group().name(), ver.artifact().group().name()
-            );
-            Assertions.assertTrue(this.vers.contains(ver.name()));
-        }
-        final List<MvnArtifactVersion> reduced =
-            new MavenCentral().findVersions(this.mine, 1, 2);
-        Assertions.assertEquals(2, reduced.size());
-        Assertions.assertEquals(
-            this.vers.get(1), reduced.get(0).name()
-        );
-        Assertions.assertEquals(
-            this.vers.get(2), reduced.get(1).name()
-        );
-    }
-
-    /**
-     * Check that asking for everything from a non-zero start works. The amount
-     * of the rows is not added to the start index in {@code int} arithmetic,
-     * so {@link Integer#MAX_VALUE} rows do not overflow into a negative end
-     * index.
-     *
-     * @throws Exception If something went wrong.
-     */
-    @Test
-    void testFindVersionsWithMaxRows() throws Exception {
-        final List<MvnArtifactVersion> versions = new MavenCentral()
-            .findVersions(this.mine, 1, Integer.MAX_VALUE);
-        Assertions.assertEquals(this.vers.size() - 1, versions.size());
-        Assertions.assertEquals(this.vers.get(1), versions.get(0).name());
-        Assertions.assertEquals(
-            this.vers.get(this.vers.size() - 1),
-            versions.get(versions.size() - 1).name()
-        );
-    }
-
-    /**
-     * Check that we correctly find the versions which are newer than provided
-     * one.
-     *
-     * @throws Exception If something went wrong.
-     */
-    @Test
-    void testFindVersionsNewerThan() throws Exception {
-        final MvnRepo mvn = new MavenCentral();
-        Assertions.assertThrows(
-            MvnException.class,
-            () -> {
-                mvn.findVersionsNewerThan(
-                    new MavenArtifactVersion(
-                        this.mine,
-                        "not-existing",
-                        MvnPackagingType.JAR,
-                        System.currentTimeMillis()
-                    )
-                );
-            }
-        );
-        final MvnArtifactVersion version = mvn.findVersions(this.mine)
-            .stream()
-            .filter(
-                ver ->
-                    this.vers.get(this.vers.size() - 2).equals(ver.name())
-            ).findFirst().get();
-        final List<MvnArtifactVersion> newer =
-            mvn.findVersionsNewerThan(version);
-        Assertions.assertEquals(MavenCentralTest.THREE, newer.size());
-        Assertions.assertEquals(this.vers.get(0), newer.get(0).name());
-        Assertions.assertEquals(this.vers.get(1), newer.get(1).name());
-        Assertions.assertEquals(this.vers.get(2), newer.get(2).name());
-    }
-
-    /**
-     * Check that we correctly find the versions which are older than provided
-     * one.
-     *
-     * @throws Exception If something went wrong.
-     */
-    @Test
-    void testFindVersionsOlderThan() throws Exception {
-        final MvnRepo mvn = new MavenCentral();
-        Assertions.assertThrows(
-            MvnException.class,
-            () -> {
-                mvn.findVersionsOlderThan(
-                    new MavenArtifactVersion(
-                        this.mine,
-                        "wrong-version",
-                        MvnPackagingType.JAR,
-                        System.currentTimeMillis()
-                    )
-                );
-            }
-        );
-        final MvnArtifactVersion version = mvn.findVersions(this.mine)
-            .stream()
-            .filter(
-                ver ->
-                    this.vers.get(2).equals(ver.name())
-            ).findFirst().get();
-        final List<MvnArtifactVersion> older =
-            mvn.findVersionsOlderThan(version);
-        Assertions.assertEquals(2, older.size());
-        Assertions.assertEquals(
-            this.vers.get(this.vers.size() - 2), older.get(0).name()
-        );
-        Assertions.assertEquals(
-            this.vers.get(this.vers.size() - 1), older.get(1).name()
-        );
-    }
-
-    /**
-     * Check that a version which does not start with a digit does not break
-     * the search of the newer versions.
-     *
-     * @throws Exception If something went wrong.
-     */
-    @Test
-    void testFindVersionsNewerThanNonNumericVersion() throws Exception {
-        final List<String> newer = names(
-            new MavenCentral().findVersionsNewerThan(this.guavaVersion("r09"))
-        );
-        Assertions.assertFalse(newer.isEmpty());
-        Assertions.assertTrue(newer.contains("10.0"));
-        Assertions.assertFalse(newer.contains("r03"));
-        Assertions.assertFalse(newer.contains("r09"));
-    }
-
-    /**
-     * Check that the versions are ordered using Maven's rules: a release
-     * candidate is older than the release, and a non-numeric version is older
-     * than a numeric one.
-     *
-     * @throws Exception If something went wrong.
-     */
-    @Test
-    void testFindVersionsOlderThanQualifiedVersion() throws Exception {
-        final List<String> older = names(
-            new MavenCentral().findVersionsOlderThan(this.guavaVersion("10.0"))
-        );
-        Assertions.assertTrue(older.contains("10.0-rc1"));
-        Assertions.assertTrue(older.contains("r09"));
-        Assertions.assertFalse(older.contains("10.0.1"));
     }
 
     /**
@@ -483,106 +715,23 @@ final class MavenCentralTest {
     }
 
     /**
-     * Check that a metadata file which declares a DTD is rejected instead of
-     * being parsed. Such a file is the vehicle for XXE: the entity below
-     * points at a local file, and an unhardened parser would happily read it
-     * and hand its content back as a version name.
+     * Create a fake which serves the metadata of both artifacts the tests
+     * use.
      *
-     * @param dir The temporary directory with the "secret" file.
-     * @throws Exception If something went wrong.
+     * @return The started fake. The caller has to close it.
+     * @throws IOException If the fake can not be started or a fixture can not
+     *  be read.
      */
-    @Test
-    void testFindVersionsRejectsMaliciousDoctype(
-        @TempDir final Path dir
-    ) throws Exception {
-        final Path secret = dir.resolve("secret.txt");
-        Files.writeString(secret, "top-secret");
-        final HttpServer server = MavenCentralTest.serving(
-            String.join(
-                "",
-                "<?xml version=\"1.0\"?>",
-                "<!DOCTYPE metadata [",
-                String.format("<!ENTITY xxe SYSTEM \"%s\">", secret.toUri()),
-                "]>",
-                "<metadata><versioning><versions>",
-                "<version>&xxe;</version>",
-                "</versions></versioning></metadata>"
+    private FakeMavenCentral serving() throws IOException {
+        return new FakeMavenCentral()
+            .withMetadata(
+                this.mine,
+                FakeMavenCentral.fixture(MavenCentralTest.MINE_METADATA)
             )
-        );
-        try {
-            final MvnRepo mvn = MavenCentralTest.talkingTo(server);
-            final Throwable cause = Assertions.assertThrows(
-                MvnException.class,
-                () -> mvn.findVersions(this.mine)
-            ).getCause();
-            Assertions.assertInstanceOf(SAXParseException.class, cause);
-            Assertions.assertTrue(
-                cause.getMessage().contains("DOCTYPE"), cause.getMessage()
+            .withMetadata(
+                this.guava,
+                FakeMavenCentral.fixture(MavenCentralTest.GUAVA_METADATA)
             );
-        } finally {
-            server.stop(0);
-        }
-    }
-
-    /**
-     * Check that hardening the parser did not break the parsing of an
-     * ordinary metadata file.
-     *
-     * @throws Exception If something went wrong.
-     */
-    @Test
-    void testFindVersionsParsesPlainMetadata() throws Exception {
-        final HttpServer server = MavenCentralTest.serving(
-            String.join(
-                "",
-                "<?xml version=\"1.0\"?>",
-                "<metadata><versioning><versions>",
-                "<version>1.0</version><version>2.0</version>",
-                "</versions></versioning></metadata>"
-            )
-        );
-        try {
-            Assertions.assertEquals(
-                Arrays.asList("2.0", "1.0"),
-                MavenCentralTest.names(
-                    MavenCentralTest.talkingTo(server).findVersions(this.mine)
-                )
-            );
-        } finally {
-            server.stop(0);
-        }
-    }
-
-    /**
-     * Check that we correctly find the versions which are newer than provided
-     * one.
-     *
-     * @throws Exception If something went wrong.
-     */
-    @Test
-    void testCompareVersionsByNumber() throws Exception {
-        final MvnRepo mvn = new MavenCentral();
-        final MavenArtifactVersion current = new MavenArtifactVersion(
-            new MavenArtifact(
-                new MavenGroup("org.junit.jupiter"),
-                "junit-jupiter-api"
-            ),
-            "5.12.2",
-            MvnPackagingType.JAR,
-            System.currentTimeMillis()
-        );
-        final List<MvnArtifactVersion> newer =
-            mvn.findVersionsNewerThan(current);
-        for (final MvnArtifactVersion version : newer) {
-            Assertions.assertTrue(
-                this.calculateNumberFromVersion(version.name())
-                    > this.calculateNumberFromVersion(current.name()),
-                String.format(
-                    "Version %s is not newer than %s.",
-                    version.name(), current.name()
-                )
-            );
-        }
     }
 
     /**
@@ -603,45 +752,15 @@ final class MavenCentralTest {
     }
 
     /**
-     * Create a repository which reads its metadata from the given local
-     * server.
+     * Create a version of my artifact.
      *
-     * @param server The server which answers the requests.
-     * @return The repository.
+     * @param name The version's name.
+     * @return The version.
      */
-    private static MvnRepo talkingTo(final HttpServer server) {
-        final String url = String.format(
-            "http://127.0.0.1:%d", server.getAddress().getPort()
+    private MvnArtifactVersion version(final String name) {
+        return new MavenArtifactVersion(
+            this.mine, name, MvnPackagingType.JAR, System.currentTimeMillis()
         );
-        return new MavenCentral(url, url);
-    }
-
-    /**
-     * Start a local HTTP server which answers every request with the given
-     * body. The caller has to stop it.
-     *
-     * @param body The body of the answer.
-     * @return The started server.
-     * @throws IOException If the server can not be started.
-     */
-    private static HttpServer serving(final String body) throws IOException {
-        final byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
-        final HttpServer server = HttpServer.create(
-            new InetSocketAddress("127.0.0.1", 0), 0
-        );
-        server.createContext(
-            "/",
-            exchange -> {
-                exchange.sendResponseHeaders(
-                    HttpURLConnection.HTTP_OK, bytes.length
-                );
-                try (OutputStream out = exchange.getResponseBody()) {
-                    out.write(bytes);
-                }
-            }
-        );
-        server.start();
-        return server;
     }
 
     /**
@@ -666,28 +785,5 @@ final class MavenCentralTest {
         final List<MvnArtifactVersion> versions
     ) {
         return versions.stream().map(MvnArtifactVersion::name).toList();
-    }
-
-    /**
-     * Calculate a numeric representation of the version.
-     * Strips pre-release identifiers (like -M1, -RC1, -SNAPSHOT) before
-     * calculating, and uses a large multiplier to handle multi-digit parts.
-     *
-     * @param version The version.
-     * @return The numeric representation.
-     */
-    private Double calculateNumberFromVersion(final String version) {
-        final String base = version.split("-")[0];
-        final String clean = base.replaceAll("[^\\d.]", "");
-        final List<String> nums = Arrays.asList(clean.split("\\."));
-        final int multiplier = 1000;
-        return IntStream
-            .range(0, nums.size())
-            .mapToDouble(
-                index ->
-                Integer.parseInt(nums.get(index))
-                    * Math.pow(multiplier, nums.size() - index - 1)
-            )
-            .sum();
     }
 }

--- a/src/test/resources/fixtures/guava-maven-metadata.xml
+++ b/src/test/resources/fixtures/guava-maven-metadata.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <groupId>com.google.guava</groupId>
+  <artifactId>guava</artifactId>
+  <versioning>
+    <latest>33.7.1-jre</latest>
+    <release>33.7.1-jre</release>
+    <versions>
+      <version>r03</version>
+      <version>r09</version>
+      <version>10.0-rc1</version>
+      <version>10.0</version>
+      <version>10.0.1</version>
+      <version>33.7.1-jre</version>
+    </versions>
+    <lastUpdated>20260818035315</lastUpdated>
+  </versioning>
+</metadata>

--- a/src/test/resources/fixtures/jenkins-sdk-maven-metadata.xml
+++ b/src/test/resources/fixtures/jenkins-sdk-maven-metadata.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <groupId>com.github.aistomin</groupId>
+  <artifactId>jenkins-sdk</artifactId>
+  <versioning>
+    <latest>0.2.1</latest>
+    <release>0.2.1</release>
+    <versions>
+      <version>0.0.1</version>
+      <version>0.0.2</version>
+      <version>0.1</version>
+      <version>0.2</version>
+      <version>0.2.1</version>
+    </versions>
+    <lastUpdated>20161118144839</lastUpdated>
+  </versioning>
+</metadata>

--- a/src/test/resources/fixtures/search-mixed-groups.json
+++ b/src/test/resources/fixtures/search-mixed-groups.json
@@ -1,0 +1,114 @@
+{
+  "responseHeader": {
+    "status": 0,
+    "QTime": 1,
+    "params": {
+      "q": "guice",
+      "core": "",
+      "defType": "dismax",
+      "qf": "text^20 g^5 a^10",
+      "indent": "off",
+      "spellcheck": "true",
+      "fl": "id,g,a,latestVersion,p,ec,repositoryId,text,timestamp,versionCount",
+      "start": "0",
+      "spellcheck.count": "5",
+      "sort": "score desc,timestamp desc,g asc,a asc",
+      "rows": "20",
+      "wt": "json",
+      "version": "2.2"
+    }
+  },
+  "response": {
+    "numFound": 979,
+    "start": 0,
+    "docs": [
+      {
+        "id": "org.openidentityplatform.commons:guice",
+        "g": "org.openidentityplatform.commons",
+        "a": "guice",
+        "latestVersion": "2.3.0",
+        "repositoryId": "central",
+        "p": "pom",
+        "timestamp": 1750337779639,
+        "versionCount": 24,
+        "text": [
+          "org.openidentityplatform.commons",
+          "guice",
+          ".pom"
+        ],
+        "ec": [
+          ".pom"
+        ]
+      },
+      {
+        "id": "io.github.replay-framework:guice",
+        "g": "io.github.replay-framework",
+        "a": "guice",
+        "latestVersion": "2.6.3",
+        "repositoryId": "central",
+        "p": "jar",
+        "timestamp": 1727896323000,
+        "versionCount": 7,
+        "text": [
+          "io.github.replay-framework",
+          "guice",
+          "-sources.jar.sha256",
+          "-javadoc.jar",
+          "-javadoc.jar.sha512",
+          ".jar.asc.sha256",
+          ".module.asc.sha256",
+          ".module.asc.sha512",
+          "-javadoc.jar.sha256",
+          ".jar.asc.sha512",
+          "-sources.jar.asc.sha512",
+          ".module",
+          ".pom.sha512",
+          "-sources.jar",
+          ".module.sha256",
+          ".pom",
+          "-sources.jar.asc.sha256",
+          ".module.sha512",
+          "-javadoc.jar.asc.sha256",
+          "-javadoc.jar.asc.sha512",
+          ".jar",
+          ".pom.asc.sha256",
+          ".pom.asc.sha512",
+          ".jar.sha512",
+          ".pom.sha256",
+          "-sources.jar.sha512",
+          ".jar.sha256"
+        ],
+        "ec": [
+          "-sources.jar.sha256",
+          "-javadoc.jar",
+          "-javadoc.jar.sha512",
+          ".jar.asc.sha256",
+          ".module.asc.sha256",
+          ".module.asc.sha512",
+          "-javadoc.jar.sha256",
+          ".jar.asc.sha512",
+          "-sources.jar.asc.sha512",
+          ".module",
+          ".pom.sha512",
+          "-sources.jar",
+          ".module.sha256",
+          ".pom",
+          "-sources.jar.asc.sha256",
+          ".module.sha512",
+          "-javadoc.jar.asc.sha256",
+          "-javadoc.jar.asc.sha512",
+          ".jar",
+          ".pom.asc.sha256",
+          ".pom.asc.sha512",
+          ".jar.sha512",
+          ".pom.sha256",
+          "-sources.jar.sha512",
+          ".jar.sha256"
+        ]
+      }
+    ]
+  },
+  "spellcheck": {
+    "suggestions": []
+  }
+}

--- a/src/test/resources/fixtures/search-single-group.json
+++ b/src/test/resources/fixtures/search-single-group.json
@@ -1,0 +1,100 @@
+{
+  "responseHeader": {
+    "status": 0,
+    "QTime": 1,
+    "params": {
+      "q": "g:\"com.github.aistomin\"",
+      "core": "",
+      "indent": "off",
+      "spellcheck": "true",
+      "fl": "id,g,a,latestVersion,p,ec,repositoryId,text,timestamp,versionCount",
+      "start": "0",
+      "spellcheck.count": "5",
+      "sort": "score desc,timestamp desc,g asc,a asc",
+      "rows": "20",
+      "wt": "json",
+      "version": "2.2"
+    }
+  },
+  "response": {
+    "numFound": 5,
+    "start": 0,
+    "docs": [
+      {
+        "id": "com.github.aistomin:testist",
+        "g": "com.github.aistomin",
+        "a": "testist",
+        "latestVersion": "1.0",
+        "repositoryId": "central",
+        "p": "jar",
+        "timestamp": 1703508004270,
+        "versionCount": 6,
+        "text": [
+          "com.github.aistomin",
+          "testist",
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          ".jar"
+        ],
+        "ec": [
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          ".jar"
+        ]
+      },
+      {
+        "id": "com.github.aistomin:maven-browser",
+        "g": "com.github.aistomin",
+        "a": "maven-browser",
+        "latestVersion": "4.0",
+        "repositoryId": "central",
+        "p": "jar",
+        "timestamp": 1700810125858,
+        "versionCount": 15,
+        "text": [
+          "com.github.aistomin",
+          "maven-browser",
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          ".jar"
+        ],
+        "ec": [
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          ".jar"
+        ]
+      },
+      {
+        "id": "com.github.aistomin:jenkins-sdk",
+        "g": "com.github.aistomin",
+        "a": "jenkins-sdk",
+        "latestVersion": "0.2.1",
+        "repositoryId": "central",
+        "p": "jar",
+        "timestamp": 1479480474000,
+        "versionCount": 5,
+        "text": [
+          "com.github.aistomin",
+          "jenkins-sdk",
+          "-sources.jar",
+          "-javadoc.jar",
+          ".jar",
+          ".pom"
+        ],
+        "ec": [
+          "-sources.jar",
+          "-javadoc.jar",
+          ".jar",
+          ".pom"
+        ]
+      }
+    ]
+  },
+  "spellcheck": {
+    "suggestions": []
+  }
+}


### PR DESCRIPTION
Every test in `MavenCentralTest` asserted on live, mutable data — an exact count of five
artifacts for `aistomin`, the exact version list of `jenkins-sdk`, whatever
`junit-jupiter-api` versions existed on the day it ran. Any release by anyone turned
master red.

## What changed

The tests now read from `FakeMavenCentral`, a localhost HTTP server which serves real
answers captured under `src/test/resources/fixtures` and **404s every path it was not
given** — so the metadata URL a lookup builds has to be right for an answer to arrive at
all. That also buys the error paths the live API will not produce on demand: HTTP 500,
malformed XML, a metadata file with no versions, a page past the last one.

| | |
|---|---|
| Live | `testFindArtifactsInMavenCentral`, `testFindVersionsInMavenCentral` |
| Fixture-backed | 10 converted, 5 new error paths, 5 migrated |
| Deleted | `testCompareVersionsByNumber` + `calculateNumberFromVersion`, `testFindVersionsParsesPlainMetadata` |

Two tests still call the real Maven Central, because a suite that only ever talks to our
own fake cannot notice that we stopped being able to talk to the real one. They assert
loosely (non-empty, `contains`, `<=`) and never on an exact count, and they still fail the
build when Maven Central is unreachable — that is deliberate.

Several tests got **stronger**, not just deterministic:

- the injection test asserted `size() <= 5` against the live API, which the real API would
  satisfy anyway; it now asserts the exact query string
  `q=a%26rows%3D1000&start=0&rows=5&wt=json`, proving the injected `rows=1000` is encoded
  into `q` rather than becoming a second parameter;
- the guava tests assert exact ordered lists (`[33.7.1-jre, 10.0.1, 10.0, 10.0-rc1]` newer
  than `r09`) instead of `contains`;
- the search-parsing fixture holds two documents from two different groups, so a reader
  that picked the group up once per answer instead of once per document could not pass.

`testCompareVersionsByNumber` is dropped along with its hand-rolled version parser: the
guava fixture proves the same ordering and covers the qualified and non-numeric versions
that parser could not read.

## Not production code

Nothing under `src/main/java` is touched, and no dependency is added — `HttpServer` ships
with the JDK. The jar this branch produces behaves identically to master's.

## Verification

`mvn clean install` — BUILD SUCCESS, 42 tests, 0 failures, JaCoCo "All coverage checks
have been met". `MavenCentralTest` went 19 → 25 tests and ~33s → ~2.8s.

## Follow-up worth a separate ticket

`MavenCentralTest` is not the only live caller. `MavenDependencyTest` makes a live
`findVersions(jenkins-sdk)` per test (7 calls) and hard-asserts `"0.2.1"`, and
`MavenArtifactVersionTest.testPackaging` does a live lookup of `maven-plugin-plugin`.
Out of scope here, since this ticket is about `MavenCentralTest`.

Closes #520