### PR TITLE
fix(#517)!: do not fabricate packaging and release timestamp

### DIFF
--- a/src/main/java/com/github/aistomin/maven/browser/MavenArtifactVersion.java
+++ b/src/main/java/com/github/aistomin/maven/browser/MavenArtifactVersion.java
@@ -15,6 +15,8 @@
  */
 package com.github.aistomin.maven.browser;
 
+import java.util.Optional;
+
 /**
  * Simple implementation of the Maven artifact's version entity.
  *
@@ -52,8 +54,11 @@ public final class MavenArtifactVersion implements MvnArtifactVersion {
      *
      * @param artifact Maven artifact.
      * @param version Maven artifact version.
-     * @param packaging Maven packaging type.
-     * @param timestamp The timestamp when the version was released.
+     * @param packaging Maven packaging type. Pass
+     *  {@link MvnPackagingType#UNKNOWN} if you do not know it.
+     * @param timestamp The timestamp when the version was released. NULL if
+     *  you do not know it, which {@link #releaseTimestamp()} gives back as an
+     *  empty {@link Optional}.
      */
     public MavenArtifactVersion(
         final MvnArtifact artifact, final String version,
@@ -76,8 +81,8 @@ public final class MavenArtifactVersion implements MvnArtifactVersion {
     }
 
     @Override
-    public Long releaseTimestamp() {
-        return this.release;
+    public Optional<Long> releaseTimestamp() {
+        return Optional.ofNullable(this.release);
     }
 
     @Override

--- a/src/main/java/com/github/aistomin/maven/browser/MavenCentral.java
+++ b/src/main/java/com/github/aistomin/maven/browser/MavenCentral.java
@@ -48,6 +48,12 @@ import org.xml.sax.SAXException;
  * fetching artifact metadata (stable).
  * Uses <a href="https://search.maven.org/">search.maven.org</a> for artifact
  * search functionality.
+ * The version listing comes from maven-metadata.xml, which holds the version
+ * names and nothing else. The versions it returns therefore say
+ * {@link MvnPackagingType#UNKNOWN} and have no release timestamp rather than
+ * claiming a packaging and a date which the repository never told us - a BOM
+ * or a Maven plugin is not a jar, and pretending otherwise was wrong for
+ * every artifact which is not one.
  *
  * @since 0.1
  */
@@ -228,7 +234,7 @@ public final class MavenCentral implements MvnRepo {
             return pagedVersions.stream()
                 .map(
                     ver -> new MavenArtifactVersion(
-                        artifact, ver, MvnPackagingType.JAR, null
+                        artifact, ver, MvnPackagingType.UNKNOWN, null
                     )
                 )
                 .collect(Collectors.toList());

--- a/src/main/java/com/github/aistomin/maven/browser/MvnArtifactVersion.java
+++ b/src/main/java/com/github/aistomin/maven/browser/MvnArtifactVersion.java
@@ -15,8 +15,15 @@
  */
 package com.github.aistomin.maven.browser;
 
+import java.util.Optional;
+
 /**
  * The interface of classes which represent the Maven artifact's version.
+ * Not every repository knows everything about a version: the packaging and
+ * the release timestamp are only available from the search API, so a version
+ * which was read out of maven-metadata.xml says so instead of pretending -
+ * see {@link MvnArtifactVersion#packaging()} and
+ * {@link MvnArtifactVersion#releaseTimestamp()}.
  *
  * @since 0.1
  */
@@ -39,9 +46,12 @@ public interface MvnArtifactVersion {
     /**
      * The timestamp when the version was released.
      *
-     * @return The timestamp.
+     * @return The timestamp, or an empty {@link Optional} if the repository
+     *  did not tell us when the version was released. The versions which
+     *  {@link MvnRepo#findVersions(MvnArtifact)} returns are always empty
+     *  here: maven-metadata.xml carries no per-version timestamp.
      */
-    Long releaseTimestamp();
+    Optional<Long> releaseTimestamp();
 
     /**
      * Artifact's version identifier. Normally it looks like
@@ -61,7 +71,10 @@ public interface MvnArtifactVersion {
     /**
      * Artifact's packaging.
      *
-     * @return Packaging type.
+     * @return Packaging type, or {@link MvnPackagingType#UNKNOWN} if the
+     *  repository did not tell us which one it is. The versions which
+     *  {@link MvnRepo#findVersions(MvnArtifact)} returns are always UNKNOWN
+     *  here: maven-metadata.xml carries no per-version packaging.
      */
     MvnPackagingType packaging();
 }

--- a/src/main/java/com/github/aistomin/maven/browser/MvnPackagingType.java
+++ b/src/main/java/com/github/aistomin/maven/browser/MvnPackagingType.java
@@ -16,7 +16,9 @@
 package com.github.aistomin.maven.browser;
 
 /**
- * The packaging types which a Maven artifact's version can have.
+ * The packaging types which a Maven artifact's version can have, plus
+ * {@link MvnPackagingType#UNKNOWN} for the versions whose packaging the
+ * repository did not tell us.
  *
  * @since 1.0
  */
@@ -60,7 +62,14 @@ public enum MvnPackagingType {
     /**
      * Packaging type "par".
      */
-    PAR("par");
+    PAR("par"),
+
+    /**
+     * The packaging type is not known. The repository did not tell us which
+     * one it is, which is what every version read out of maven-metadata.xml
+     * looks like: that file carries no per-version packaging at all.
+     */
+    UNKNOWN("unknown");
 
     /**
      * Packaging type as it appears in pom.xml.

--- a/src/main/java/com/github/aistomin/maven/browser/MvnRepo.java
+++ b/src/main/java/com/github/aistomin/maven/browser/MvnRepo.java
@@ -52,6 +52,10 @@ public interface MvnRepo {
 
     /**
      * Search for the versions of the artifact. Returns first 20 found versions.
+     * A repository which lists the versions out of maven-metadata.xml learns
+     * nothing but their names from it, so the versions come back with
+     * {@link MvnPackagingType#UNKNOWN} packaging and an empty release
+     * timestamp.
      *
      * @param artifact The artifact.
      * @return The list of the found versions of the artifact.
@@ -66,6 +70,8 @@ public interface MvnRepo {
      * The range is clamped to the amount of the versions which the repository
      * has, so {@code rows} may be {@link Integer#MAX_VALUE} to ask for
      * everything starting from {@code start}.
+     * The versions carry as much as the repository told us about them - see
+     * {@link #findVersions(MvnArtifact)}.
      *
      * @param artifact The artifact.
      * @param start Indent of the search.
@@ -79,7 +85,8 @@ public interface MvnRepo {
 
     /**
      * Search for all the versions of the artifact which are newer than provided
-     * version.
+     * version. The versions carry as much as the repository told us about
+     * them - see {@link #findVersions(MvnArtifact)}.
      *
      * @param version The version.
      * @return The list of the newer versions.
@@ -92,7 +99,8 @@ public interface MvnRepo {
 
     /**
      * Search for all the versions of the artifact which are older than provided
-     * version.
+     * version. The versions carry as much as the repository told us about
+     * them - see {@link #findVersions(MvnArtifact)}.
      *
      * @param version The version.
      * @return The list of the older versions.

--- a/src/test/java/com/github/aistomin/maven/browser/MavenArtifactVersionTest.java
+++ b/src/test/java/com/github/aistomin/maven/browser/MavenArtifactVersionTest.java
@@ -17,7 +17,7 @@ package com.github.aistomin.maven.browser;
 
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.List;
+import java.util.Optional;
 import java.util.Random;
 import java.util.UUID;
 import org.junit.jupiter.api.Assertions;
@@ -54,7 +54,8 @@ final class MavenArtifactVersionTest {
         Assertions.assertEquals(artifact, version.artifact());
         Assertions.assertEquals(type, version.packaging());
         Assertions.assertEquals(
-            MavenArtifactVersionTest.TIMESTAMP, version.releaseTimestamp()
+            Optional.of(MavenArtifactVersionTest.TIMESTAMP),
+            version.releaseTimestamp()
         );
         Assertions.assertEquals(
             String.format("%s:%s", artifact.identifier(), name),
@@ -106,24 +107,23 @@ final class MavenArtifactVersionTest {
     }
 
     /**
-     * Check that we properly assign and return the packaging of the artifact.
-     * Note: When using repo1.maven.org (maven-metadata.xml), packaging info
-     * is not available and defaults to JAR. This test verifies that behavior.
-     * The packaging which is passed to the ctor is checked in testConstruct().
+     * Check that a version which was built without a release timestamp says
+     * so, instead of handing out a NULL which the caller unboxes into an NPE.
+     * That is how every version read out of maven-metadata.xml is built - see
+     * {@link MavenCentralTest#testFindVersionsDoesNotFabricateMetadata()}.
      */
     @Test
-    void testPackaging() throws Exception {
-        final List<MvnArtifactVersion> versions =
-            new MavenCentral().findVersions(
+    void testUnknownReleaseTimestamp() {
+        Assertions.assertTrue(
+            new MavenArtifactVersion(
                 new MavenArtifact(
-                    new MavenGroup("org.apache.maven.plugins"),
-                    "maven-plugin-plugin"
-                )
-            );
-        for (final MvnArtifactVersion version : versions) {
-            Assertions.assertEquals(
-                MvnPackagingType.JAR, version.packaging()
-            );
-        }
+                    new MavenGroup(UUID.randomUUID().toString()),
+                    UUID.randomUUID().toString()
+                ),
+                UUID.randomUUID().toString(),
+                MvnPackagingType.UNKNOWN,
+                null
+            ).releaseTimestamp().isEmpty()
+        );
     }
 }

--- a/src/test/java/com/github/aistomin/maven/browser/MavenCentralTest.java
+++ b/src/test/java/com/github/aistomin/maven/browser/MavenCentralTest.java
@@ -75,6 +75,12 @@ final class MavenCentralTest {
         "guava-maven-metadata.xml";
 
     /**
+     * The name of the fixture with the metadata of the JUnit BOM.
+     */
+    private static final String BOM_METADATA =
+        "junit-bom-maven-metadata.xml";
+
+    /**
      * My previously created artifact which we can use for tests.
      */
     private final MvnArtifact mine = new MavenArtifact(
@@ -88,6 +94,14 @@ final class MavenCentralTest {
      */
     private final MvnArtifact guava = new MavenArtifact(
         new MavenGroup("com.google.guava"), "guava"
+    );
+
+    /**
+     * The JUnit BOM. Its packaging is "pom", not "jar", which is what makes it
+     * the artifact to check that we do not fabricate a packaging.
+     */
+    private final MvnArtifact bom = new MavenArtifact(
+        new MavenGroup("org.junit"), "junit-bom"
     );
 
     /**
@@ -423,6 +437,30 @@ final class MavenCentralTest {
     }
 
     /**
+     * Check that the versions we read out of maven-metadata.xml admit what
+     * that file does not say. It carries the version names and nothing else,
+     * so claiming a packaging or a release date would be making it up. The
+     * artifact here is a BOM, whose packaging is "pom": before, every one of
+     * its versions came back calling itself a jar.
+     *
+     * @throws Exception If something went wrong.
+     */
+    @Test
+    void testFindVersionsDoesNotFabricateMetadata() throws Exception {
+        try (FakeMavenCentral fake = this.serving()) {
+            final List<MvnArtifactVersion> versions =
+                fake.browser().findVersions(this.bom);
+            Assertions.assertFalse(versions.isEmpty());
+            for (final MvnArtifactVersion ver : versions) {
+                Assertions.assertEquals(
+                    MvnPackagingType.UNKNOWN, ver.packaging()
+                );
+                Assertions.assertTrue(ver.releaseTimestamp().isEmpty());
+            }
+        }
+    }
+
+    /**
      * Check that we correctly find the versions which are newer than provided
      * one.
      *
@@ -731,6 +769,10 @@ final class MavenCentralTest {
             .withMetadata(
                 this.guava,
                 FakeMavenCentral.fixture(MavenCentralTest.GUAVA_METADATA)
+            )
+            .withMetadata(
+                this.bom,
+                FakeMavenCentral.fixture(MavenCentralTest.BOM_METADATA)
             );
     }
 

--- a/src/test/resources/fixtures/junit-bom-maven-metadata.xml
+++ b/src/test/resources/fixtures/junit-bom-maven-metadata.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <groupId>org.junit</groupId>
+  <artifactId>junit-bom</artifactId>
+  <versioning>
+    <latest>5.4.0</latest>
+    <release>5.4.0</release>
+    <versions>
+      <version>5.2.0</version>
+      <version>5.3.0</version>
+      <version>5.3.1</version>
+      <version>5.3.2</version>
+      <version>5.4.0</version>
+    </versions>
+    <lastUpdated>20190211174936</lastUpdated>
+  </versioning>
+</metadata>


### PR DESCRIPTION
`MavenCentral.findVersions` reads the version list out of `maven-metadata.xml`,
which carries version names and nothing else, yet it built every version as
`MvnPackagingType.JAR` with a `null` release timestamp. That was wrong for every
artifact which is not a jar — a BOM, a parent pom, a war, a maven-plugin — and
the `null` was undocumented, so a caller unboxing it got an NPE.

This is the ticket's option 1: stop fabricating. Enriching versions with the real
packaging and timestamps from the search API's `gav` core stays a separate,
follow-up decision.

### What changed

- `MvnPackagingType` gets an `UNKNOWN("unknown")` constant.
- `MvnArtifactVersion.releaseTimestamp()` returns `Optional<Long>`.
- `MavenCentral.findVersions` builds versions as `UNKNOWN` with no timestamp.
- Javadoc on `MvnRepo`'s four version-returning methods, on `MvnArtifactVersion`
  and on `MavenCentral` says what the repository does and does not tell us.

The `MavenArtifactVersion` constructor keeps its nullable `Long timestamp`
parameter, so *building* a version is unaffected; only *reading* the timestamp
back changed.

### Tests

- New fixture `junit-bom-maven-metadata.xml` — `org.junit:junit-bom` has real
  `pom` packaging, so it is the non-jar artifact the ticket asks for.
- New `MavenCentralTest#testFindVersionsDoesNotFabricateMetadata` asserts every
  returned version is `UNKNOWN` with an empty timestamp.
- `MavenArtifactVersionTest#testPackaging` was calling the **real** Maven Central
  (it is not named `*InMavenCentral`, so it slipped past the fixture conversion in
  #520) and asserting `JAR`. Replaced by `testUnknownReleaseTimestamp`; its subject
  now lives in the fixture-based test above.

`mvn clean install` is green: 43 tests, Checkstyle, doclint, PMD, duplicate-finder
and JaCoCo 95% all pass.

### Downstream impact

`maven-dependencies-analyser` needs **no changes**. It never calls
`releaseTimestamp()`, never calls `packaging()` on a version, and nothing there
implements `MvnArtifactVersion`; it only constructs `MavenArtifactVersion` (whose
signature is untouched) and iterates `MvnPackagingType.values()` comparing
`packaging()` strings, which a new `"unknown"` never matches. Verified by building
it against `5.2-SNAPSHOT` with a temporary, uncommitted version bump: 18 tests, green.

**BREAKING CHANGE:** `MvnArtifactVersion.releaseTimestamp()` returns
`Optional<Long>` instead of `Long`, and `MvnPackagingType` has a new `UNKNOWN`
constant. Callers which unboxed the timestamp or switched exhaustively over the
enum need to adapt.

Closes #517