### PR TITLE
ci(#549): replace deprecated setup-java inputs with their env-var names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,10 +117,10 @@ jobs:
           distribution: 'temurin'
           cache: maven
           server-id: central
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
+          server-username-env-var: MAVEN_USERNAME
+          server-password-env-var: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+          gpg-passphrase-env-var: MAVEN_GPG_PASSPHRASE
 
       - name: Bump version references
         run: |


### PR DESCRIPTION
actions/setup-java@v6 deprecates `server-username`, `server-password` and `gpg-passphrase` in favour of the `*-env-var` aliases. The values already name environment variables, so only the keys change — `server-id` and `gpg-private-key` are not deprecated and stay untouched.

This removes the three deprecation warnings from every run of the "Release to Maven Central" workflow before the aliases are dropped. Per the ticket's acceptance criteria, a dry run of the release workflow after merging should show no deprecation warnings and still GPG-sign all four artifacts.

Closes #549